### PR TITLE
Fix build for workflow projects

### DIFF
--- a/serene/src/Serene.Web/Initialization/Startup.cs
+++ b/serene/src/Serene.Web/Initialization/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serenity.Extensions.DependencyInjection;
+using Serenity.Workflow;
 using Serenity.Localization;
 using System.IO;
 

--- a/src/Serenity.Workflow.Abstractions/Serenity.Workflow.Abstractions.csproj
+++ b/src/Serenity.Workflow.Abstractions/Serenity.Workflow.Abstractions.csproj
@@ -6,6 +6,8 @@
     <Title>Serenity Workflow - Abstractions</Title>
   </PropertyGroup>
   <ItemGroup>
+    <Using Remove="Serenity.*" />
     <PackageReference Include="Stateless" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Serenity.Workflow.Core/Serenity.Workflow.Core.csproj
+++ b/src/Serenity.Workflow.Core/Serenity.Workflow.Core.csproj
@@ -6,7 +6,9 @@
     <Title>Serenity Workflow - Core Engine</Title>
   </PropertyGroup>
   <ItemGroup>
+    <Using Remove="Serenity.*" />
     <ProjectReference Include="..\Serenity.Workflow.Abstractions\Serenity.Workflow.Abstractions.csproj" />
     <PackageReference Include="Stateless" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Serenity.Workflow.DbProvider/Provider/DatabaseWorkflowDefinitionProvider.cs
+++ b/src/Serenity.Workflow.DbProvider/Provider/DatabaseWorkflowDefinitionProvider.cs
@@ -15,15 +15,16 @@ namespace Serenity.Workflow.Provider
         public WorkflowDefinition? GetDefinition(string workflowKey)
         {
             using var connection = connections.NewByKey("Default");
-            var definition = connection.TryById<Entities.WorkflowDefinitionRow>(workflowKey);
+            var fields = Entities.WorkflowDefinitionRow.Fields;
+            var definition = connection.TryFirst<Entities.WorkflowDefinitionRow>(fields.WorkflowKey == workflowKey);
             if (definition == null)
                 return null;
             var def = new WorkflowDefinition { WorkflowKey = workflowKey, InitialState = definition.InitialState! };
-            def.States = connection.List<Entities.WorkflowStateRow>(Entities.WorkflowStateRow.Fields.DefinitionId == definition.Id)
+            def.States = connection.List<Entities.WorkflowStateRow>(Entities.WorkflowStateRow.Fields.DefinitionId == definition.Id!.Value)
                 .ToDictionary(x => x.StateKey! , x => new WorkflowState { StateKey = x.StateKey!, DisplayName = x.Name });
-            def.Triggers = connection.List<Entities.WorkflowTriggerRow>(Entities.WorkflowTriggerRow.Fields.DefinitionId == definition.Id)
+            def.Triggers = connection.List<Entities.WorkflowTriggerRow>(Entities.WorkflowTriggerRow.Fields.DefinitionId == definition.Id!.Value)
                 .ToDictionary(x => x.TriggerKey!, x => new WorkflowTrigger { TriggerKey = x.TriggerKey!, DisplayName = x.Name, HandlerKey = x.HandlerKey, RequiresInput = x.RequiresInput ?? false, FormKey = x.FormKey });
-            def.Transitions = connection.List<Entities.WorkflowTransitionRow>(Entities.WorkflowTransitionRow.Fields.DefinitionId == definition.Id)
+            def.Transitions = connection.List<Entities.WorkflowTransitionRow>(Entities.WorkflowTransitionRow.Fields.DefinitionId == definition.Id!.Value)
                 .Select(x => new WorkflowTransition { From = x.FromState!, To = x.ToState!, Trigger = x.TriggerKey!, GuardKey = x.GuardKey }).ToList();
             return def;
         }


### PR DESCRIPTION
## Summary
- remove Serenity.* global usings from workflow projects so they compile
- add DI abstraction reference to workflow projects
- fix DatabaseWorkflowDefinitionProvider queries
- import Serenity.Workflow namespace in Serene startup

## Testing
- `dotnet build Serenity.sln -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_68416096af20832e838a9b6d9c38fdfe