### PR TITLE
Add TaskWorkflow test UI

### DIFF
--- a/serene/src/Serene.Web/Imports/MVC/ESM.cs
+++ b/serene/src/Serene.Web/Imports/MVC/ESM.cs
@@ -9,6 +9,7 @@ public static partial class ESM
     public const string SignUpPage = "~/esm/Modules/Membership/Account/SignUp/SignUpPage.js";
     public const string TranslationPage = "~/esm/Modules/Administration/Translation/TranslationPage.js";
     public const string UserPage = "~/esm/Modules/Administration/User/UserPage.js";
+    public const string TaskItemPage = "~/esm/Modules/Tasks/TaskItem/TaskItemPage.js";
 
     public static partial class Modules
     {
@@ -29,13 +30,20 @@ public static partial class ESM
                 public const string TranslationPage = "~/esm/Modules/Administration/Translation/TranslationPage.js";
             }
 
-            public static partial class User
+        public static partial class User
+        {
+            public const string UserPage = "~/esm/Modules/Administration/User/UserPage.js";
+        }
+        public static partial class Tasks
+        {
+            public static partial class TaskItem
             {
-                public const string UserPage = "~/esm/Modules/Administration/User/UserPage.js";
+                public const string TaskItemPage = "~/esm/Modules/Tasks/TaskItem/TaskItemPage.js";
             }
         }
+    }
 
-        public static partial class Common
+    public static partial class Common
         {
             public const string ScriptInit = "~/esm/Modules/Common/ScriptInit.js";
         }

--- a/serene/src/Serene.Web/Modules/ServerTypes/Tasks.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Tasks.ts
@@ -1,0 +1,4 @@
+export * from "./Tasks/TaskItemColumns";
+export * from "./Tasks/TaskItemForm";
+export * from "./Tasks/TaskItemRow";
+export * from "./Tasks/TaskItemService";

--- a/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemColumns.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemColumns.ts
@@ -1,0 +1,13 @@
+import { ColumnsBase, fieldsProxy } from "@serenity-is/corelib";
+import { Column } from "@serenity-is/sleekgrid";
+import { TaskItemRow } from "./TaskItemRow";
+
+export interface TaskItemColumns {
+    Title: Column<TaskItemRow>;
+    State: Column<TaskItemRow>;
+}
+
+export class TaskItemColumns extends ColumnsBase<TaskItemRow> {
+    static readonly columnsKey = 'Tasks.TaskItem';
+    static readonly Fields = fieldsProxy<TaskItemColumns>();
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemForm.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemForm.ts
@@ -1,0 +1,26 @@
+import { StringEditor, PrefixedContext, initFormType } from "@serenity-is/corelib";
+
+export interface TaskItemForm {
+    Title: StringEditor;
+    State: StringEditor;
+}
+
+export class TaskItemForm extends PrefixedContext {
+    static readonly formKey = 'Tasks.TaskItem';
+    private static init: boolean;
+
+    constructor(prefix: string) {
+        super(prefix);
+
+        if (!TaskItemForm.init)  {
+            TaskItemForm.init = true;
+
+            var w0 = StringEditor;
+
+            initFormType(TaskItemForm, [
+                'Title', w0,
+                'State', w0
+            ]);
+        }
+    }
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemRow.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemRow.ts
@@ -1,0 +1,25 @@
+import { getLookup, getLookupAsync, fieldsProxy } from "@serenity-is/corelib";
+
+export interface TaskItemRow {
+    TaskId?: number;
+    Title?: string;
+    State?: string;
+}
+
+export abstract class TaskItemRow {
+    static readonly idProperty = 'TaskId';
+    static readonly nameProperty = 'Title';
+    static readonly localTextPrefix = 'Tasks.TaskItem';
+    static readonly lookupKey = 'Tasks.TaskItem';
+
+    /** @deprecated use getLookupAsync instead */
+    static getLookup() { return getLookup<TaskItemRow>('Tasks.TaskItem') }
+    static async getLookupAsync() { return getLookupAsync<TaskItemRow>('Tasks.TaskItem') }
+
+    static readonly deletePermission = 'Task:Modify';
+    static readonly insertPermission = 'Task:Modify';
+    static readonly readPermission = 'Task:View';
+    static readonly updatePermission = 'Task:Modify';
+
+    static readonly Fields = fieldsProxy<TaskItemRow>();
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemService.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Tasks/TaskItemService.ts
@@ -1,0 +1,32 @@
+import { SaveRequest, SaveResponse, ServiceOptions, DeleteRequest, DeleteResponse, RetrieveRequest, RetrieveResponse, ListRequest, ListResponse, serviceRequest } from "@serenity-is/corelib";
+import { TaskItemRow } from "./TaskItemRow";
+
+export namespace TaskItemService {
+    export const baseUrl = 'Tasks/TaskItem';
+
+    export declare function Create(request: SaveRequest<TaskItemRow>, onSuccess?: (response: SaveResponse) => void, opt?: ServiceOptions<any>): PromiseLike<SaveResponse>;
+    export declare function Update(request: SaveRequest<TaskItemRow>, onSuccess?: (response: SaveResponse) => void, opt?: ServiceOptions<any>): PromiseLike<SaveResponse>;
+    export declare function Delete(request: DeleteRequest, onSuccess?: (response: DeleteResponse) => void, opt?: ServiceOptions<any>): PromiseLike<DeleteResponse>;
+    export declare function Retrieve(request: RetrieveRequest, onSuccess?: (response: RetrieveResponse<TaskItemRow>) => void, opt?: ServiceOptions<any>): PromiseLike<RetrieveResponse<TaskItemRow>>;
+    export declare function List(request: ListRequest, onSuccess?: (response: ListResponse<TaskItemRow>) => void, opt?: ServiceOptions<any>): PromiseLike<ListResponse<TaskItemRow>>;
+
+    export const Methods = {
+        Create: "Tasks/TaskItem/Create",
+        Update: "Tasks/TaskItem/Update",
+        Delete: "Tasks/TaskItem/Delete",
+        Retrieve: "Tasks/TaskItem/Retrieve",
+        List: "Tasks/TaskItem/List"
+    } as const;
+
+    [
+        'Create',
+        'Update',
+        'Delete',
+        'Retrieve',
+        'List'
+    ].forEach(x => {
+        (<any>TaskItemService)[x] = function (r: any, s: any, o: any) {
+            return serviceRequest(baseUrl + '/' + x, r, s, o);
+        };
+    });
+}

--- a/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemDeleteHandler.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemDeleteHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Tasks.TaskItemRow;
+using MyRequest = Serenity.Services.DeleteRequest;
+using MyResponse = Serenity.Services.DeleteResponse;
+
+namespace Serene.Tasks;
+
+public interface ITaskItemDeleteHandler : IDeleteHandler<MyRow, MyRequest, MyResponse> { }
+
+public class TaskItemDeleteHandler(IRequestContext context)
+    : DeleteRequestHandler<MyRow, MyRequest, MyResponse>(context), ITaskItemDeleteHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemListHandler.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemListHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Tasks.TaskItemRow;
+using MyRequest = Serenity.Services.ListRequest;
+using MyResponse = Serenity.Services.ListResponse<Serene.Tasks.TaskItemRow>;
+
+namespace Serene.Tasks;
+
+public interface ITaskItemListHandler : IListHandler<MyRow, MyRequest, MyResponse> { }
+
+public class TaskItemListHandler(IRequestContext context)
+    : ListRequestHandler<MyRow, MyRequest, MyResponse>(context), ITaskItemListHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemRetrieveHandler.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemRetrieveHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Tasks.TaskItemRow;
+using MyRequest = Serenity.Services.RetrieveRequest;
+using MyResponse = Serenity.Services.RetrieveResponse<Serene.Tasks.TaskItemRow>;
+
+namespace Serene.Tasks;
+
+public interface ITaskItemRetrieveHandler : IRetrieveHandler<MyRow, MyRequest, MyResponse> { }
+
+public class TaskItemRetrieveHandler(IRequestContext context)
+    : RetrieveRequestHandler<MyRow, MyRequest, MyResponse>(context), ITaskItemRetrieveHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemSaveHandler.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/RequestHandlers/TaskItemSaveHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Tasks.TaskItemRow;
+using MyRequest = Serenity.Services.SaveRequest<Serene.Tasks.TaskItemRow>;
+using MyResponse = Serenity.Services.SaveResponse;
+
+namespace Serene.Tasks;
+
+public interface ITaskItemSaveHandler : ISaveHandler<MyRow, MyRequest, MyResponse> { }
+
+public class TaskItemSaveHandler(IRequestContext context)
+    : SaveRequestHandler<MyRow, MyRequest, MyResponse>(context), ITaskItemSaveHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemColumns.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemColumns.cs
@@ -1,0 +1,10 @@
+namespace Serene.Tasks.Forms;
+
+[ColumnsScript("Tasks.TaskItem")]
+[BasedOnRow(typeof(TaskItemRow), CheckNames = true)]
+public class TaskItemColumns
+{
+    [EditLink]
+    public string Title { get; set; }
+    public string State { get; set; }
+}

--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemDialog.ts
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemDialog.ts
@@ -1,0 +1,66 @@
+import { Decorators, EntityDialog } from "@serenity-is/corelib";
+import { TaskItemRow, TaskItemForm, TaskItemService } from "../ServerTypes/Tasks";
+import { WorkflowService } from "../Workflow/Client/WorkflowService";
+
+const startBtn = 'start-workflow';
+const finishBtn = 'finish-workflow';
+
+@Decorators.registerClass('Serene.Tasks.TaskItemDialog')
+export class TaskItemDialog extends EntityDialog<TaskItemRow, any> {
+    protected getFormKey() { return TaskItemForm.formKey; }
+    protected getIdProperty() { return TaskItemRow.idProperty; }
+    protected getLocalTextPrefix() { return TaskItemRow.localTextPrefix; }
+    protected getNameProperty() { return TaskItemRow.nameProperty; }
+    protected getService() { return TaskItemService.baseUrl; }
+
+    protected form = new TaskItemForm(this.idPrefix);
+
+    protected getToolbarButtons() {
+        let buttons = super.getToolbarButtons();
+
+        buttons.push({
+            title: 'Start',
+            cssClass: startBtn,
+            icon: 'fa-play text-purple',
+            onClick: () => this.executeAction('Start')
+        });
+
+        buttons.push({
+            title: 'Finish',
+            cssClass: finishBtn,
+            icon: 'fa-flag-checkered text-purple',
+            onClick: () => this.executeAction('Finish')
+        });
+
+        return buttons;
+    }
+
+    private executeAction(trigger: string) {
+        WorkflowService.ExecuteAction({
+            WorkflowKey: 'TaskWorkflow',
+            CurrentState: this.entity.State ?? '',
+            Trigger: trigger,
+            Input: { EntityId: this.entity.TaskId }
+        }).then(() => this.loadById(this.entity.TaskId));
+    }
+
+    protected updateInterface() {
+        super.updateInterface();
+
+        const start = this.toolbar.findButton(startBtn);
+        const finish = this.toolbar.findButton(finishBtn);
+        if (this.isNewOrDeleted()) {
+            start.addClass('disabled');
+            finish.addClass('disabled');
+            return;
+        }
+
+        WorkflowService.GetPermittedActions({
+            WorkflowKey: 'TaskWorkflow',
+            CurrentState: this.entity.State ?? ''
+        }).then(r => {
+            start.toggleClass('disabled', r.Actions.indexOf('Start') < 0);
+            finish.toggleClass('disabled', r.Actions.indexOf('Finish') < 0);
+        });
+    }
+}

--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemEndpoint.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemEndpoint.cs
@@ -1,0 +1,36 @@
+using MyRow = Serene.Tasks.TaskItemRow;
+
+namespace Serene.Tasks.Endpoints;
+
+[Route("Services/Tasks/TaskItem/[action]")]
+[ConnectionKey(typeof(MyRow)), ServiceAuthorize(typeof(MyRow))]
+public class TaskItemEndpoint : ServiceEndpoint
+{
+    [HttpPost, AuthorizeCreate(typeof(MyRow))]
+    public SaveResponse Create(IUnitOfWork uow, SaveRequest<MyRow> request, [FromServices] ITaskItemSaveHandler handler)
+    {
+        return handler.Create(uow, request);
+    }
+
+    [HttpPost, AuthorizeUpdate(typeof(MyRow))]
+    public SaveResponse Update(IUnitOfWork uow, SaveRequest<MyRow> request, [FromServices] ITaskItemSaveHandler handler)
+    {
+        return handler.Update(uow, request);
+    }
+
+    [HttpPost, AuthorizeDelete(typeof(MyRow))]
+    public DeleteResponse Delete(IUnitOfWork uow, DeleteRequest request, [FromServices] ITaskItemDeleteHandler handler)
+    {
+        return handler.Delete(uow, request);
+    }
+
+    public RetrieveResponse<MyRow> Retrieve(IDbConnection connection, RetrieveRequest request, [FromServices] ITaskItemRetrieveHandler handler)
+    {
+        return handler.Retrieve(connection, request);
+    }
+
+    public ListResponse<MyRow> List(IDbConnection connection, ListRequest request, [FromServices] ITaskItemListHandler handler)
+    {
+        return handler.List(connection, request);
+    }
+}

--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemForm.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemForm.cs
@@ -1,0 +1,9 @@
+namespace Serene.Tasks.Forms;
+
+[FormScript("Tasks.TaskItem")]
+[BasedOnRow(typeof(TaskItemRow), CheckNames = true)]
+public class TaskItemForm
+{
+    public string Title { get; set; }
+    public string State { get; set; }
+}

--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemGrid.ts
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemGrid.ts
@@ -1,0 +1,13 @@
+import { EntityGrid, Decorators } from "@serenity-is/corelib";
+import { TaskItemRow, TaskItemColumns, TaskItemService } from "../ServerTypes/Tasks";
+import { TaskItemDialog } from "./TaskItemDialog";
+
+@Decorators.registerClass('Serene.Tasks.TaskItemGrid')
+export class TaskItemGrid extends EntityGrid<TaskItemRow, any> {
+    protected useAsync() { return true; }
+    protected getColumnsKey() { return TaskItemColumns.columnsKey; }
+    protected getDialogType() { return TaskItemDialog; }
+    protected getIdProperty() { return TaskItemRow.idProperty; }
+    protected getLocalTextPrefix() { return TaskItemRow.localTextPrefix; }
+    protected getService() { return TaskItemService.baseUrl; }
+}

--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemPage.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemPage.cs
@@ -1,0 +1,11 @@
+namespace Serene.Tasks.Pages;
+
+[PageAuthorize(typeof(TaskItemRow))]
+public class TaskItemPage : Controller
+{
+    [Route("Tasks/TaskItem")]
+    public ActionResult Index()
+    {
+        return this.GridPage("@/Tasks/TaskItem/TaskItemPage", TaskItemRow.Fields.PageTitle());
+    }
+}

--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemPage.ts
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemPage.ts
@@ -1,0 +1,4 @@
+import { gridPageInit } from "@serenity-is/corelib";
+import { TaskItemGrid } from "./TaskItemGrid";
+
+export default () => gridPageInit(TaskItemGrid);

--- a/serene/src/Serene.Web/Modules/Tasks/TaskNavigation.cs
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskNavigation.cs
@@ -1,0 +1,4 @@
+using TasksPages = Serene.Tasks.Pages;
+
+[assembly: NavigationMenu(6000, "Tasks", icon: "fa-tasks")]
+[assembly: NavigationLink(6100, "Tasks/Task Items", typeof(TasksPages.TaskItemPage), icon: "fa-tasks")]


### PR DESCRIPTION
## Summary
- create TaskItem CRUD UI with workflow actions
- wire TaskItem page in navigation
- expose TaskItemPage via ESM imports
- add Task server typings

## Testing
- `pnpm -r test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68416cf7f424832ea124b772bca665a4