### PR TITLE
Enable workflow migrations on startup

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -3,3 +3,5 @@
 This repository includes a minimal workflow engine implementation. Workflows are defined in the database and loaded by `DatabaseWorkflowDefinitionProvider`. You can enable a row by using `[WorkflowEnabled("WorkflowKey")]` and specify the state field with `[WorkflowStateField]`.
 
 Services are registered in `Startup.cs` via `AddSerenityWorkflow()` and `AddWorkflowDbProvider()`. Generic endpoints are available under `Services/Workflow`.
+
+Database tables for the workflow entities are created automatically during application startup as the provider assembly now includes FluentMigrator migrations.

--- a/src/Serenity.Workflow.DbProvider/AssemblyInfo.cs
+++ b/src/Serenity.Workflow.DbProvider/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Serenity.ComponentModel;
+
+[assembly: TypeSourceAssembly]

--- a/src/Serenity.Workflow.DbProvider/Migrations/WorkflowMigrations.cs
+++ b/src/Serenity.Workflow.DbProvider/Migrations/WorkflowMigrations.cs
@@ -1,8 +1,9 @@
 using FluentMigrator;
+using Serenity.Extensions;
 
 namespace Serenity.Workflow.Migrations
 {
-    [Migration(2024051601)]
+    [DefaultDB, MigrationKey(20250605_1405)]
     public class WorkflowMigrations : Migration
     {
         public override void Up()


### PR DESCRIPTION
## Summary
- ensure Serenity.Workflow.DbProvider assembly is discovered by the type source
- tag WorkflowMigrations with DefaultDB and MigrationKey so it runs at startup
- document automatic workflow table creation

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841707a921c832e82759dac916faf97