### PR TITLE
Fix null workflow key

### DIFF
--- a/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
+++ b/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
@@ -18,6 +18,8 @@ namespace Serenity.Workflow
 
         private StateMachine<string, string> GetMachine(string workflowKey)
         {
+            ArgumentNullException.ThrowIfNull(workflowKey);
+
             return machines.GetOrAdd(workflowKey, key =>
             {
                 var def = definitionProvider.GetDefinition(key) ?? throw new InvalidOperationException($"Workflow {key} not found");
@@ -43,6 +45,10 @@ namespace Serenity.Workflow
 
         public async Task ExecuteAsync(string workflowKey, string currentState, string trigger, IDictionary<string, object?>? input)
         {
+            ArgumentNullException.ThrowIfNull(workflowKey);
+            ArgumentNullException.ThrowIfNull(currentState);
+            ArgumentNullException.ThrowIfNull(trigger);
+
             var machine = GetMachine(workflowKey);
             var action = definitionProvider.GetDefinition(workflowKey)?.Triggers[trigger];
             var handler = action?.HandlerKey != null ? services.GetService(Type.GetType(action.HandlerKey)!) as IWorkflowActionHandler : null;
@@ -53,6 +59,9 @@ namespace Serenity.Workflow
 
         public IEnumerable<string> GetPermittedTriggers(string workflowKey, string state)
         {
+            ArgumentNullException.ThrowIfNull(workflowKey);
+            ArgumentNullException.ThrowIfNull(state);
+
             var machine = GetMachine(workflowKey);
             machine.Activate();
             return machine.PermittedTriggers;

--- a/tests/Serenity.Net.Tests/workflow/WorkflowEngineTests.cs
+++ b/tests/Serenity.Net.Tests/workflow/WorkflowEngineTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Serenity.Workflow;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -39,6 +40,18 @@ namespace Serenity.Net.Tests.Workflow
             engine.ExecuteAsync("Test", "Draft", "Submit", null).GetAwaiter().GetResult();
             var permitted = engine.GetPermittedTriggers("Test", "Submitted");
             Assert.DoesNotContain("Submit", permitted);
+        }
+
+        [Fact]
+        public void GetPermittedTriggersThrowsOnNullWorkflowKey()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IWorkflowDefinitionProvider, SimpleProvider>();
+            services.AddSerenityWorkflow();
+            var provider = services.BuildServiceProvider();
+            var engine = provider.GetRequiredService<WorkflowEngine>();
+
+            Assert.Throws<ArgumentNullException>(() => engine.GetPermittedTriggers(null!, "Draft"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle `null` workflow keys in `WorkflowEngine`
- cover null workflow keys with unit test

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684190c21908832e904530b77e54384d