### PR TITLE
Add workflow management GUI

### DIFF
--- a/serene/src/Serene.Web/Modules/ServerTypes/Workflow.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Workflow.ts
@@ -1,1 +1,5 @@
-﻿export * from "./Workflow/WorkflowService"
+export * from "./Workflow/Client/WorkflowService";
+export * from "./Workflow/WorkflowDefinitionColumns";
+export * from "./Workflow/WorkflowDefinitionForm";
+export * from "./Workflow/WorkflowDefinitionRow";
+export * from "./Workflow/WorkflowDefinitionService";

--- a/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionColumns.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionColumns.ts
@@ -1,0 +1,14 @@
+import { ColumnsBase, fieldsProxy } from "@serenity-is/corelib";
+import { Column } from "@serenity-is/sleekgrid";
+import { WorkflowDefinitionRow } from "./WorkflowDefinitionRow";
+
+export interface WorkflowDefinitionColumns {
+    WorkflowKey: Column<WorkflowDefinitionRow>;
+    Name: Column<WorkflowDefinitionRow>;
+    InitialState: Column<WorkflowDefinitionRow>;
+}
+
+export class WorkflowDefinitionColumns extends ColumnsBase<WorkflowDefinitionRow> {
+    static readonly columnsKey = 'Workflow.WorkflowDefinition';
+    static readonly Fields = fieldsProxy<WorkflowDefinitionColumns>();
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionForm.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionForm.ts
@@ -1,0 +1,28 @@
+import { StringEditor, PrefixedContext, initFormType } from "@serenity-is/corelib";
+
+export interface WorkflowDefinitionForm {
+    WorkflowKey: StringEditor;
+    Name: StringEditor;
+    InitialState: StringEditor;
+}
+
+export class WorkflowDefinitionForm extends PrefixedContext {
+    static readonly formKey = 'Workflow.WorkflowDefinition';
+    private static init: boolean;
+
+    constructor(prefix: string) {
+        super(prefix);
+
+        if (!WorkflowDefinitionForm.init) {
+            WorkflowDefinitionForm.init = true;
+
+            var w0 = StringEditor;
+
+            initFormType(WorkflowDefinitionForm, [
+                'WorkflowKey', w0,
+                'Name', w0,
+                'InitialState', w0
+            ]);
+        }
+    }
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionRow.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionRow.ts
@@ -1,0 +1,20 @@
+import { fieldsProxy } from "@serenity-is/corelib";
+
+export interface WorkflowDefinitionRow {
+    Id?: number;
+    WorkflowKey?: string;
+    Name?: string;
+    InitialState?: string;
+}
+
+export abstract class WorkflowDefinitionRow {
+    static readonly idProperty = 'Id';
+    static readonly nameProperty = 'WorkflowKey';
+    static readonly localTextPrefix = 'Workflow.WorkflowDefinition';
+    static readonly deletePermission = 'Workflow:Modify';
+    static readonly insertPermission = 'Workflow:Modify';
+    static readonly readPermission = 'Workflow:View';
+    static readonly updatePermission = 'Workflow:Modify';
+
+    static readonly Fields = fieldsProxy<WorkflowDefinitionRow>();
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionService.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Workflow/WorkflowDefinitionService.ts
@@ -1,0 +1,32 @@
+import { SaveRequest, SaveResponse, ServiceOptions, DeleteRequest, DeleteResponse, RetrieveRequest, RetrieveResponse, ListRequest, ListResponse, serviceRequest } from "@serenity-is/corelib";
+import { WorkflowDefinitionRow } from "./WorkflowDefinitionRow";
+
+export namespace WorkflowDefinitionService {
+    export const baseUrl = 'Workflow/Definitions';
+
+    export declare function Create(request: SaveRequest<WorkflowDefinitionRow>, onSuccess?: (response: SaveResponse) => void, opt?: ServiceOptions<any>): PromiseLike<SaveResponse>;
+    export declare function Update(request: SaveRequest<WorkflowDefinitionRow>, onSuccess?: (response: SaveResponse) => void, opt?: ServiceOptions<any>): PromiseLike<SaveResponse>;
+    export declare function Delete(request: DeleteRequest, onSuccess?: (response: DeleteResponse) => void, opt?: ServiceOptions<any>): PromiseLike<DeleteResponse>;
+    export declare function Retrieve(request: RetrieveRequest, onSuccess?: (response: RetrieveResponse<WorkflowDefinitionRow>) => void, opt?: ServiceOptions<any>): PromiseLike<RetrieveResponse<WorkflowDefinitionRow>>;
+    export declare function List(request: ListRequest, onSuccess?: (response: ListResponse<WorkflowDefinitionRow>) => void, opt?: ServiceOptions<any>): PromiseLike<ListResponse<WorkflowDefinitionRow>>;
+
+    export const Methods = {
+        Create: "Workflow/Definitions/Create",
+        Update: "Workflow/Definitions/Update",
+        Delete: "Workflow/Definitions/Delete",
+        Retrieve: "Workflow/Definitions/Retrieve",
+        List: "Workflow/Definitions/List"
+    } as const;
+
+    [
+        'Create',
+        'Update',
+        'Delete',
+        'Retrieve',
+        'List'
+    ].forEach(x => {
+        (<any>WorkflowDefinitionService)[x] = function (r: any, s: any, o: any) {
+            return serviceRequest(baseUrl + '/' + x, r, s, o);
+        };
+    });
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionDeleteHandler.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionDeleteHandler.cs
@@ -1,0 +1,13 @@
+using Serenity.Services;
+using MyRow = Serenity.Workflow.Entities.WorkflowDefinitionRow;
+using MyRequest = DeleteRequest;
+using MyResponse = DeleteResponse;
+
+namespace Serene.WorkflowManagement;
+
+public interface IWorkflowDefinitionDeleteHandler : IDeleteHandler<MyRow, MyRequest, MyResponse> { }
+
+public class WorkflowDefinitionDeleteHandler(IRequestContext context)
+    : DeleteRequestHandler<MyRow, MyRequest, MyResponse>(context), IWorkflowDefinitionDeleteHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionListHandler.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionListHandler.cs
@@ -1,0 +1,13 @@
+using Serenity.Services;
+using MyRow = Serenity.Workflow.Entities.WorkflowDefinitionRow;
+using MyRequest = ListRequest;
+using MyResponse = ListResponse<Serenity.Workflow.Entities.WorkflowDefinitionRow>;
+
+namespace Serene.WorkflowManagement;
+
+public interface IWorkflowDefinitionListHandler : IListHandler<MyRow, MyRequest, MyResponse> { }
+
+public class WorkflowDefinitionListHandler(IRequestContext context)
+    : ListRequestHandler<MyRow, MyRequest, MyResponse>(context), IWorkflowDefinitionListHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionRetrieveHandler.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionRetrieveHandler.cs
@@ -1,0 +1,13 @@
+using Serenity.Services;
+using MyRow = Serenity.Workflow.Entities.WorkflowDefinitionRow;
+using MyRequest = RetrieveRequest;
+using MyResponse = RetrieveResponse<Serenity.Workflow.Entities.WorkflowDefinitionRow>;
+
+namespace Serene.WorkflowManagement;
+
+public interface IWorkflowDefinitionRetrieveHandler : IRetrieveHandler<MyRow, MyRequest, MyResponse> { }
+
+public class WorkflowDefinitionRetrieveHandler(IRequestContext context)
+    : RetrieveRequestHandler<MyRow, MyRequest, MyResponse>(context), IWorkflowDefinitionRetrieveHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionSaveHandler.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/RequestHandlers/WorkflowDefinitionSaveHandler.cs
@@ -1,0 +1,13 @@
+using Serenity.Services;
+using MyRow = Serenity.Workflow.Entities.WorkflowDefinitionRow;
+using MyRequest = SaveRequest<Serenity.Workflow.Entities.WorkflowDefinitionRow>;
+using MyResponse = SaveResponse;
+
+namespace Serene.WorkflowManagement;
+
+public interface IWorkflowDefinitionSaveHandler : ISaveHandler<MyRow, MyRequest, MyResponse> { }
+
+public class WorkflowDefinitionSaveHandler(IRequestContext context)
+    : SaveRequestHandler<MyRow, MyRequest, MyResponse>(context), IWorkflowDefinitionSaveHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionColumns.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionColumns.cs
@@ -1,0 +1,11 @@
+namespace Serene.WorkflowManagement.Forms;
+
+[ColumnsScript("Workflow.WorkflowDefinition")]
+[BasedOnRow(typeof(Serenity.Workflow.Entities.WorkflowDefinitionRow), CheckNames = true)]
+public class WorkflowDefinitionColumns
+{
+    [EditLink]
+    public string WorkflowKey { get; set; }
+    public string Name { get; set; }
+    public string InitialState { get; set; }
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionDialog.ts
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionDialog.ts
@@ -1,0 +1,13 @@
+import { Decorators, EntityDialog } from "@serenity-is/corelib";
+import { WorkflowDefinitionRow, WorkflowDefinitionForm, WorkflowDefinitionService } from "../ServerTypes/Workflow";
+
+@Decorators.registerClass('Serene.WorkflowManagement.WorkflowDefinitionDialog')
+export class WorkflowDefinitionDialog extends EntityDialog<WorkflowDefinitionRow, any> {
+    protected getFormKey() { return WorkflowDefinitionForm.formKey; }
+    protected getIdProperty() { return WorkflowDefinitionRow.idProperty; }
+    protected getLocalTextPrefix() { return WorkflowDefinitionRow.localTextPrefix; }
+    protected getNameProperty() { return WorkflowDefinitionRow.nameProperty; }
+    protected getService() { return WorkflowDefinitionService.baseUrl; }
+
+    protected form = new WorkflowDefinitionForm(this.idPrefix);
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionEndpoint.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionEndpoint.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using Serenity.Data;
+using Serenity.Services;
+using MyRow = Serenity.Workflow.Entities.WorkflowDefinitionRow;
+
+namespace Serene.WorkflowManagement;
+
+[Route("Services/Workflow/Definitions/[action]")]
+[ConnectionKey(typeof(MyRow)), ServiceAuthorize(typeof(MyRow))]
+public class WorkflowDefinitionEndpoint : ServiceEndpoint
+{
+    [HttpPost, AuthorizeCreate(typeof(MyRow))]
+    public SaveResponse Create(IUnitOfWork uow, SaveRequest<MyRow> request, [FromServices] IWorkflowDefinitionSaveHandler handler)
+    {
+        return handler.Create(uow, request);
+    }
+
+    [HttpPost, AuthorizeUpdate(typeof(MyRow))]
+    public SaveResponse Update(IUnitOfWork uow, SaveRequest<MyRow> request, [FromServices] IWorkflowDefinitionSaveHandler handler)
+    {
+        return handler.Update(uow, request);
+    }
+
+    [HttpPost, AuthorizeDelete(typeof(MyRow))]
+    public DeleteResponse Delete(IUnitOfWork uow, DeleteRequest request, [FromServices] IWorkflowDefinitionDeleteHandler handler)
+    {
+        return handler.Delete(uow, request);
+    }
+
+    public RetrieveResponse<MyRow> Retrieve(IDbConnection connection, RetrieveRequest request, [FromServices] IWorkflowDefinitionRetrieveHandler handler)
+    {
+        return handler.Retrieve(connection, request);
+    }
+
+    public ListResponse<MyRow> List(IDbConnection connection, ListRequest request, [FromServices] IWorkflowDefinitionListHandler handler)
+    {
+        return handler.List(connection, request);
+    }
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionForm.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionForm.cs
@@ -1,0 +1,10 @@
+namespace Serene.WorkflowManagement.Forms;
+
+[FormScript("Workflow.WorkflowDefinition")]
+[BasedOnRow(typeof(Serenity.Workflow.Entities.WorkflowDefinitionRow), CheckNames = true)]
+public class WorkflowDefinitionForm
+{
+    public string WorkflowKey { get; set; }
+    public string Name { get; set; }
+    public string InitialState { get; set; }
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionGrid.ts
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionGrid.ts
@@ -1,0 +1,12 @@
+import { EntityGrid, Decorators } from "@serenity-is/corelib";
+import { WorkflowDefinitionRow, WorkflowDefinitionColumns, WorkflowDefinitionService } from "../ServerTypes/Workflow";
+import { WorkflowDefinitionDialog } from "./WorkflowDefinitionDialog";
+
+@Decorators.registerClass('Serene.WorkflowManagement.WorkflowDefinitionGrid')
+export class WorkflowDefinitionGrid extends EntityGrid<WorkflowDefinitionRow, any> {
+    protected getColumnsKey() { return WorkflowDefinitionColumns.columnsKey; }
+    protected getDialogType() { return WorkflowDefinitionDialog; }
+    protected getIdProperty() { return WorkflowDefinitionRow.idProperty; }
+    protected getLocalTextPrefix() { return WorkflowDefinitionRow.localTextPrefix; }
+    protected getService() { return WorkflowDefinitionService.baseUrl; }
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionPage.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionPage.cs
@@ -1,0 +1,11 @@
+namespace Serene.WorkflowManagement.Pages;
+
+[PageAuthorize(typeof(Serenity.Workflow.Entities.WorkflowDefinitionRow))]
+public class WorkflowDefinitionPage : Controller
+{
+    [Route("Workflow/Definitions")]
+    public ActionResult Index()
+    {
+        return this.GridPage("@/WorkflowManagement/WorkflowDefinitionPage", Serenity.Workflow.Entities.WorkflowDefinitionRow.Fields.PageTitle());
+    }
+}

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionPage.ts
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowDefinitionPage.ts
@@ -1,0 +1,4 @@
+import { gridPageInit } from "@serenity-is/corelib";
+import { WorkflowDefinitionGrid } from "./WorkflowDefinitionGrid";
+
+export default () => gridPageInit(WorkflowDefinitionGrid);

--- a/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowNavigation.cs
+++ b/serene/src/Serene.Web/Modules/WorkflowManagement/WorkflowNavigation.cs
@@ -1,0 +1,4 @@
+using WorkflowPages = Serene.WorkflowManagement.Pages;
+
+[assembly: NavigationMenu(12000, "Workflow", icon: "fa-random")]
+[assembly: NavigationLink(12100, "Workflow/Definitions", typeof(WorkflowPages.WorkflowDefinitionPage), icon: "fa-random")]

--- a/src/Serenity.Workflow.DbProvider/Entities/WorkflowDefinitionRow.cs
+++ b/src/Serenity.Workflow.DbProvider/Entities/WorkflowDefinitionRow.cs
@@ -4,14 +4,19 @@ using Serenity.Data.Mapping;
 
 namespace Serenity.Workflow.Entities
 {
-    [ConnectionKey("Default"), TableName("WorkflowDefinitions")]
-    public class WorkflowDefinitionRow : Row<WorkflowDefinitionRow.RowFields>
+    [ConnectionKey("Default"), Module("Workflow"), TableName("WorkflowDefinitions")]
+    [DisplayName("Workflow Definitions"), InstanceName("Workflow Definition")]
+    [ReadPermission("Workflow:View"), ModifyPermission("Workflow:Modify")]
+    public class WorkflowDefinitionRow : Row<WorkflowDefinitionRow.RowFields>, IIdRow, INameRow
     {
         [Identity, IdProperty]
         public int? Id { get => fields.Id[this]; set => fields.Id[this] = value; }
         public string? WorkflowKey { get => fields.WorkflowKey[this]; set => fields.WorkflowKey[this] = value; }
         public string? Name { get => fields.Name[this]; set => fields.Name[this] = value; }
         public string? InitialState { get => fields.InitialState[this]; set => fields.InitialState[this] = value; }
+
+        Int32Field IIdRow.IdField => fields.Id;
+        StringField INameRow.NameField => fields.WorkflowKey;
 
         public class RowFields : RowFieldsBase
         {


### PR DESCRIPTION
## Summary
- extend `WorkflowDefinitionRow` with display info and permissions
- expose CRUD endpoint for workflow definitions
- add workflow navigation
- add basic grid and dialog for workflow definitions
- provide TypeScript server typings and client code

## Testing
- `pnpm -r test` *(fails: Cannot find package 'esbuild')*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a46c8cb4832eabf486bfad89c7da