### PR TITLE
Dynamic workflow action buttons

### DIFF
--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemDialog.ts
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemDialog.ts
@@ -1,12 +1,9 @@
-import { Decorators, EntityDialog } from "@serenity-is/corelib";
+import { Decorators } from "@serenity-is/corelib";
 import { TaskItemRow, TaskItemForm, TaskItemService } from "../ServerTypes/Tasks";
-import { WorkflowService } from "../Workflow/Client/WorkflowService";
-
-const startBtn = 'start-workflow';
-const finishBtn = 'finish-workflow';
+import { WorkflowEntityDialog } from "../Workflow/Client/WorkflowEntityDialog";
 
 @Decorators.registerClass('Serene.Tasks.TaskItemDialog')
-export class TaskItemDialog extends EntityDialog<TaskItemRow, any> {
+export class TaskItemDialog extends WorkflowEntityDialog<TaskItemRow, any> {
     protected getFormKey() { return TaskItemForm.formKey; }
     protected getIdProperty() { return TaskItemRow.idProperty; }
     protected getLocalTextPrefix() { return TaskItemRow.localTextPrefix; }
@@ -15,52 +12,6 @@ export class TaskItemDialog extends EntityDialog<TaskItemRow, any> {
 
     protected form = new TaskItemForm(this.idPrefix);
 
-    protected getToolbarButtons() {
-        let buttons = super.getToolbarButtons();
-
-        buttons.push({
-            title: 'Start',
-            cssClass: startBtn,
-            icon: 'fa-play text-purple',
-            onClick: () => this.executeAction('Start')
-        });
-
-        buttons.push({
-            title: 'Finish',
-            cssClass: finishBtn,
-            icon: 'fa-flag-checkered text-purple',
-            onClick: () => this.executeAction('Finish')
-        });
-
-        return buttons;
-    }
-
-    private executeAction(trigger: string) {
-        WorkflowService.ExecuteAction({
-            WorkflowKey: 'TaskWorkflow',
-            CurrentState: this.entity.State ?? '',
-            Trigger: trigger,
-            Input: { EntityId: this.entity.TaskId }
-        }).then(() => this.loadById(this.entity.TaskId));
-    }
-
-    protected updateInterface() {
-        super.updateInterface();
-
-        const start = this.toolbar.findButton(startBtn);
-        const finish = this.toolbar.findButton(finishBtn);
-        if (this.isNewOrDeleted()) {
-            start.addClass('disabled');
-            finish.addClass('disabled');
-            return;
-        }
-
-        WorkflowService.GetPermittedActions({
-            WorkflowKey: 'TaskWorkflow',
-            CurrentState: this.entity.State ?? ''
-        }).then(r => {
-            start.toggleClass('disabled', r.Actions.indexOf('Start') < 0);
-            finish.toggleClass('disabled', r.Actions.indexOf('Finish') < 0);
-        });
-    }
+    protected getWorkflowKey() { return 'TaskWorkflow'; }
+    protected getStateProperty() { return 'State'; }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.ts
@@ -1,0 +1,61 @@
+import { EntityDialog, ToolButton, Decorators } from "@serenity-is/corelib";
+import { WorkflowService, WorkflowDefinition } from "./WorkflowService";
+
+@Decorators.registerClass('Serene.Workflow.WorkflowEntityDialog')
+export abstract class WorkflowEntityDialog<TItem, TOptions> extends EntityDialog<TItem, TOptions> {
+
+    protected abstract getWorkflowKey(): string;
+    protected abstract getStateProperty(): keyof TItem;
+
+    private workflow?: WorkflowDefinition;
+
+    protected async ensureDefinition() {
+        if (this.workflow)
+            return;
+        const r = await WorkflowService.GetDefinition({ WorkflowKey: this.getWorkflowKey() });
+        this.workflow = r.Definition!;
+    }
+
+    protected override async getToolbarButtons(): Promise<ToolButton[]> {
+        const buttons = super.getToolbarButtons();
+        await this.ensureDefinition();
+        if (this.workflow) {
+            for (const key of Object.keys(this.workflow.Triggers)) {
+                const trigger = this.workflow.Triggers[key];
+                buttons.push({
+                    title: trigger.DisplayName || trigger.TriggerKey,
+                    cssClass: `trigger-${trigger.TriggerKey}`,
+                    icon: 'fa-play text-purple',
+                    onClick: () => this.executeAction(trigger.TriggerKey)
+                });
+            }
+        }
+        return buttons;
+    }
+
+    private executeAction(trigger: string) {
+        const entity: any = this.entity as any;
+        WorkflowService.ExecuteAction({
+            WorkflowKey: this.getWorkflowKey(),
+            CurrentState: entity[this.getStateProperty()] ?? '',
+            Trigger: trigger,
+            Input: { EntityId: entity[this.getIdProperty()] }
+        }).then(() => this.loadById(entity[this.getIdProperty()]));
+    }
+
+    protected override updateInterface() {
+        super.updateInterface();
+        const entity: any = this.entity as any;
+        if (!this.workflow)
+            return;
+        WorkflowService.GetPermittedActions({
+            WorkflowKey: this.getWorkflowKey(),
+            CurrentState: entity[this.getStateProperty()] ?? ''
+        }).then(r => {
+            for (const key of Object.keys(this.workflow!.Triggers)) {
+                const btn = this.toolbar.findButton(`trigger-${key}`);
+                btn.toggleClass('disabled', r.Actions.indexOf(key) < 0 || this.isNewOrDeleted());
+            }
+        });
+    }
+}

--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowService.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowService.ts
@@ -16,6 +16,30 @@ export interface GetPermittedActionsResponse extends ServiceResponse {
     Actions: string[];
 }
 
+export interface GetWorkflowDefinitionRequest extends ServiceRequest {
+    WorkflowKey: string;
+}
+
+export interface WorkflowTrigger {
+    TriggerKey: string;
+    DisplayName?: string;
+    HandlerKey?: string;
+    FormKey?: string;
+    RequiresInput?: boolean;
+}
+
+export interface WorkflowDefinition {
+    WorkflowKey: string;
+    InitialState: string;
+    States: { [key: string]: { StateKey: string; DisplayName?: string } };
+    Triggers: { [key: string]: WorkflowTrigger };
+    Transitions: { From: string; Trigger: string; To: string; GuardKey?: string }[];
+}
+
+export interface GetWorkflowDefinitionResponse extends ServiceResponse {
+    Definition?: WorkflowDefinition;
+}
+
 export namespace WorkflowService {
     export const baseUrl = 'Workflow';
 
@@ -25,5 +49,9 @@ export namespace WorkflowService {
 
     export function GetPermittedActions(request: GetPermittedActionsRequest) {
         return serviceRequest<GetPermittedActionsResponse>(baseUrl + '/GetPermittedActions', request);
+    }
+
+    export function GetDefinition(request: GetWorkflowDefinitionRequest) {
+        return serviceRequest<GetWorkflowDefinitionResponse>(baseUrl + '/GetDefinition', request);
     }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/WorkflowEndpoint.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/WorkflowEndpoint.cs
@@ -20,5 +20,13 @@ namespace Serene.Workflow
             var actions = engine.GetPermittedTriggers(request.WorkflowKey, request.CurrentState);
             return new GetPermittedActionsResponse { Actions = actions.ToList() };
         }
+
+        [HttpPost]
+        public GetWorkflowDefinitionResponse GetDefinition(GetWorkflowDefinitionRequest request,
+            [FromServices] IWorkflowDefinitionProvider provider)
+        {
+            var def = provider.GetDefinition(request.WorkflowKey);
+            return new GetWorkflowDefinitionResponse { Definition = def };
+        }
     }
 }

--- a/src/Serenity.Workflow.Core/Requests/GetWorkflowDefinitionRequest.cs
+++ b/src/Serenity.Workflow.Core/Requests/GetWorkflowDefinitionRequest.cs
@@ -1,0 +1,9 @@
+using Serenity.Services;
+
+namespace Serenity.Workflow
+{
+    public class GetWorkflowDefinitionRequest : ServiceRequest
+    {
+        public required string WorkflowKey { get; set; }
+    }
+}

--- a/src/Serenity.Workflow.Core/Requests/GetWorkflowDefinitionResponse.cs
+++ b/src/Serenity.Workflow.Core/Requests/GetWorkflowDefinitionResponse.cs
@@ -1,0 +1,9 @@
+using Serenity.Services;
+
+namespace Serenity.Workflow
+{
+    public class GetWorkflowDefinitionResponse : ServiceResponse
+    {
+        public WorkflowDefinition? Definition { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add requests to fetch workflow definition
- extend workflow endpoint with `GetDefinition`
- expose workflow definition APIs to TypeScript
- implement `WorkflowEntityDialog` mixin
- update `TaskItemDialog` to use dynamic workflow buttons

## Testing
- `pnpm i` *(fails: `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`)*
- `dotnet test` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841c6e93870832e8d995125d725baa6