### PR TITLE
Fix getStateProperty type

### DIFF
--- a/serene/src/Serene.Web/Modules/Tasks/TaskItemDialog.ts
+++ b/serene/src/Serene.Web/Modules/Tasks/TaskItemDialog.ts
@@ -13,5 +13,5 @@ export class TaskItemDialog extends WorkflowEntityDialog<TaskItemRow, any> {
     protected form = new TaskItemForm(this.idPrefix);
 
     protected getWorkflowKey() { return 'TaskWorkflow'; }
-    protected getStateProperty() { return 'State'; }
+    protected getStateProperty(): keyof TaskItemRow { return 'State'; }
 }


### PR DESCRIPTION
## Summary
- make `TaskItemDialog.getStateProperty` explicitly return `keyof TaskItemRow`

## Testing
- `pnpm -r build` *(fails: Cannot find package 'esbuild')*
- `pnpm install` *(fails: workspace package `@serenity-is/sleekgrid` missing)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9008f04832e8ba182b33fea0beb