### PR TITLE
Add complex document workflow example

### DIFF
--- a/serene/src/Serene.Web/Initialization/DocumentWorkflowDefinitionProvider.cs
+++ b/serene/src/Serene.Web/Initialization/DocumentWorkflowDefinitionProvider.cs
@@ -1,0 +1,50 @@
+using Serenity.Workflow;
+
+namespace Serene;
+
+public class DocumentWorkflowDefinitionProvider : IWorkflowDefinitionProvider
+{
+    public WorkflowDefinition? GetDefinition(string workflowKey)
+    {
+        if (workflowKey != "DocumentWorkflow")
+            return null;
+
+        return new WorkflowDefinition
+        {
+            WorkflowKey = "DocumentWorkflow",
+            InitialState = "Draft",
+            States = new()
+            {
+                ["Draft"] = new WorkflowState { StateKey = "Draft", DisplayName = "Draft" },
+                ["Submitted"] = new WorkflowState { StateKey = "Submitted", DisplayName = "Submitted" },
+                ["UnderReview"] = new WorkflowState { StateKey = "UnderReview", DisplayName = "Under Review" },
+                ["ChangesRequested"] = new WorkflowState { StateKey = "ChangesRequested", DisplayName = "Changes Requested" },
+                ["Resubmitted"] = new WorkflowState { StateKey = "Resubmitted", DisplayName = "Resubmitted" },
+                ["FinalReview"] = new WorkflowState { StateKey = "FinalReview", DisplayName = "Final Review" },
+                ["Approved"] = new WorkflowState { StateKey = "Approved", DisplayName = "Approved" },
+                ["Rejected"] = new WorkflowState { StateKey = "Rejected", DisplayName = "Rejected" }
+            },
+            Triggers = new()
+            {
+                ["Submit"] = new WorkflowTrigger { TriggerKey = "Submit", DisplayName = "Submit", RequiresInput = true },
+                ["StartReview"] = new WorkflowTrigger { TriggerKey = "StartReview", DisplayName = "Start Review" },
+                ["RequestChanges"] = new WorkflowTrigger { TriggerKey = "RequestChanges", DisplayName = "Request Changes", RequiresInput = true },
+                ["Resubmit"] = new WorkflowTrigger { TriggerKey = "Resubmit", DisplayName = "Resubmit", RequiresInput = true },
+                ["StartFinalReview"] = new WorkflowTrigger { TriggerKey = "StartFinalReview", DisplayName = "Start Final Review" },
+                ["Approve"] = new WorkflowTrigger { TriggerKey = "Approve", DisplayName = "Approve" },
+                ["Reject"] = new WorkflowTrigger { TriggerKey = "Reject", DisplayName = "Reject", RequiresInput = true }
+            },
+            Transitions = new()
+            {
+                new WorkflowTransition { From = "Draft", Trigger = "Submit", To = "Submitted" },
+                new WorkflowTransition { From = "Submitted", Trigger = "StartReview", To = "UnderReview" },
+                new WorkflowTransition { From = "UnderReview", Trigger = "RequestChanges", To = "ChangesRequested" },
+                new WorkflowTransition { From = "ChangesRequested", Trigger = "Resubmit", To = "Resubmitted" },
+                new WorkflowTransition { From = "Resubmitted", Trigger = "StartFinalReview", To = "FinalReview" },
+                new WorkflowTransition { From = "UnderReview", Trigger = "Reject", To = "Rejected", GuardKey = typeof(Workflow.ApprovalPermissionGuard).FullName },
+                new WorkflowTransition { From = "FinalReview", Trigger = "Approve", To = "Approved", GuardKey = typeof(Workflow.ApprovalPermissionGuard).FullName },
+                new WorkflowTransition { From = "FinalReview", Trigger = "Reject", To = "Rejected", GuardKey = typeof(Workflow.ApprovalPermissionGuard).FullName }
+            }
+        };
+    }
+}

--- a/serene/src/Serene.Web/Initialization/Startup.cs
+++ b/serene/src/Serene.Web/Initialization/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serenity.Extensions.DependencyInjection;
 using Serenity.Workflow;
+using Serene.Workflow;
 using Serenity.Localization;
 using System.IO;
 
@@ -111,7 +112,9 @@ public partial class Startup
         services.AddWorkflowDbProvider();
         services.AddTransient<Workflow.StartTaskWorkflowHandler>();
         services.AddTransient<Workflow.FinishTaskWorkflowHandler>();
+        services.AddTransient<Workflow.ApprovalPermissionGuard>();
         services.AddSingleton<IWorkflowDefinitionProvider, SampleWorkflowDefinitionProvider>();
+        services.AddSingleton<IWorkflowDefinitionProvider, DocumentWorkflowDefinitionProvider>();
     }
 
     public static void InitializeLocalTexts(IServiceProvider services)

--- a/serene/src/Serene.Web/Modules/Workflow/Guards/ApprovalPermissionGuard.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Guards/ApprovalPermissionGuard.cs
@@ -1,0 +1,12 @@
+using Serenity.Abstractions;
+using Serenity.Workflow;
+
+namespace Serene.Workflow;
+
+public class ApprovalPermissionGuard(IPermissionService permissions) : IWorkflowGuard
+{
+    public Task<bool> CanExecuteAsync(IServiceProvider services, object instance)
+    {
+        return Task.FromResult(permissions.HasPermission("Document:Approve"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `DocumentWorkflowDefinitionProvider` with many states, triggers and guard usage
- implement a `ApprovalPermissionGuard` guard class
- register new workflow provider and guard in `Startup`

## Testing
- `pnpm -r build` *(fails: Cannot find package 'esbuild')*
- `pnpm install` *(fails: workspace package not found)*
- `dotnet build Serenity.sln /p:SkipNodeScripts=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d10aa378832eaa3190e22404fae8