### PR TITLE
Add document workflow module

### DIFF
--- a/serene/src/Serene.Web/Migrations/DefaultDB/DefaultDB_20240516_1300_Documents.cs
+++ b/serene/src/Serene.Web/Migrations/DefaultDB/DefaultDB_20240516_1300_Documents.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+
+namespace Serene.Migrations.DefaultDB;
+
+[DefaultDB, MigrationKey(20240516_1300)]
+public class DefaultDB_20240516_1300_Documents : AutoReversingMigration
+{
+    public override void Up()
+    {
+        Create.Table("Documents")
+            .WithColumn("DocumentId").AsInt32().Identity().PrimaryKey()
+            .WithColumn("Title").AsString(100).NotNullable()
+            .WithColumn("State").AsString(50).NotNullable();
+    }
+}

--- a/serene/src/Serene.Web/Modules/Documents/DocumentColumns.cs
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentColumns.cs
@@ -1,0 +1,10 @@
+namespace Serene.Documents.Forms;
+
+[ColumnsScript("Documents.Document")]
+[BasedOnRow(typeof(DocumentRow), CheckNames = true)]
+public class DocumentColumns
+{
+    [EditLink]
+    public string Title { get; set; }
+    public string State { get; set; }
+}

--- a/serene/src/Serene.Web/Modules/Documents/DocumentDialog.ts
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentDialog.ts
@@ -1,0 +1,17 @@
+import { Decorators } from "@serenity-is/corelib";
+import { DocumentRow, DocumentForm, DocumentService } from "../ServerTypes/Documents";
+import { WorkflowEntityDialog } from "../Workflow/Client/WorkflowEntityDialog";
+
+@Decorators.registerClass('Serene.Documents.DocumentDialog')
+export class DocumentDialog extends WorkflowEntityDialog<DocumentRow, any> {
+    protected getFormKey() { return DocumentForm.formKey; }
+    protected getIdProperty() { return DocumentRow.idProperty; }
+    protected getLocalTextPrefix() { return DocumentRow.localTextPrefix; }
+    protected getNameProperty() { return DocumentRow.nameProperty; }
+    protected getService() { return DocumentService.baseUrl; }
+
+    protected form = new DocumentForm(this.idPrefix);
+
+    protected getWorkflowKey() { return 'DocumentWorkflow'; }
+    protected getStateProperty(): keyof DocumentRow { return 'State'; }
+}

--- a/serene/src/Serene.Web/Modules/Documents/DocumentEndpoint.cs
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentEndpoint.cs
@@ -1,0 +1,36 @@
+using MyRow = Serene.Documents.DocumentRow;
+
+namespace Serene.Documents.Endpoints;
+
+[Route("Services/Documents/Document/[action]")]
+[ConnectionKey(typeof(MyRow)), ServiceAuthorize(typeof(MyRow))]
+public class DocumentEndpoint : ServiceEndpoint
+{
+    [HttpPost, AuthorizeCreate(typeof(MyRow))]
+    public SaveResponse Create(IUnitOfWork uow, SaveRequest<MyRow> request, [FromServices] IDocumentSaveHandler handler)
+    {
+        return handler.Create(uow, request);
+    }
+
+    [HttpPost, AuthorizeUpdate(typeof(MyRow))]
+    public SaveResponse Update(IUnitOfWork uow, SaveRequest<MyRow> request, [FromServices] IDocumentSaveHandler handler)
+    {
+        return handler.Update(uow, request);
+    }
+
+    [HttpPost, AuthorizeDelete(typeof(MyRow))]
+    public DeleteResponse Delete(IUnitOfWork uow, DeleteRequest request, [FromServices] IDocumentDeleteHandler handler)
+    {
+        return handler.Delete(uow, request);
+    }
+
+    public RetrieveResponse<MyRow> Retrieve(IDbConnection connection, RetrieveRequest request, [FromServices] IDocumentRetrieveHandler handler)
+    {
+        return handler.Retrieve(connection, request);
+    }
+
+    public ListResponse<MyRow> List(IDbConnection connection, ListRequest request, [FromServices] IDocumentListHandler handler)
+    {
+        return handler.List(connection, request);
+    }
+}

--- a/serene/src/Serene.Web/Modules/Documents/DocumentForm.cs
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentForm.cs
@@ -1,0 +1,9 @@
+namespace Serene.Documents.Forms;
+
+[FormScript("Documents.Document")]
+[BasedOnRow(typeof(DocumentRow), CheckNames = true)]
+public class DocumentForm
+{
+    public string Title { get; set; }
+    public string State { get; set; }
+}

--- a/serene/src/Serene.Web/Modules/Documents/DocumentGrid.ts
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentGrid.ts
@@ -1,0 +1,13 @@
+import { EntityGrid, Decorators } from "@serenity-is/corelib";
+import { DocumentRow, DocumentColumns, DocumentService } from "../ServerTypes/Documents";
+import { DocumentDialog } from "./DocumentDialog";
+
+@Decorators.registerClass('Serene.Documents.DocumentGrid')
+export class DocumentGrid extends EntityGrid<DocumentRow, any> {
+    protected useAsync() { return true; }
+    protected getColumnsKey() { return DocumentColumns.columnsKey; }
+    protected getDialogType() { return DocumentDialog; }
+    protected getIdProperty() { return DocumentRow.idProperty; }
+    protected getLocalTextPrefix() { return DocumentRow.localTextPrefix; }
+    protected getService() { return DocumentService.baseUrl; }
+}

--- a/serene/src/Serene.Web/Modules/Documents/DocumentNavigation.cs
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentNavigation.cs
@@ -1,0 +1,4 @@
+using DocumentsPages = Serene.Documents.Pages;
+
+[assembly: NavigationMenu(6200, "Documents", icon: "fa-file")]
+[assembly: NavigationLink(6210, "Documents/Document", typeof(DocumentsPages.DocumentPage), icon: "fa-file")]

--- a/serene/src/Serene.Web/Modules/Documents/DocumentPage.cs
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentPage.cs
@@ -1,0 +1,11 @@
+namespace Serene.Documents.Pages;
+
+[PageAuthorize(typeof(DocumentRow))]
+public class DocumentPage : Controller
+{
+    [Route("Documents/Document")]
+    public ActionResult Index()
+    {
+        return this.GridPage("@/Documents/DocumentPage", DocumentRow.Fields.PageTitle());
+    }
+}

--- a/serene/src/Serene.Web/Modules/Documents/DocumentPage.ts
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentPage.ts
@@ -1,0 +1,4 @@
+import { gridPageInit } from "@serenity-is/corelib";
+import { DocumentGrid } from "./DocumentGrid";
+
+export default () => gridPageInit(DocumentGrid);

--- a/serene/src/Serene.Web/Modules/Documents/DocumentRow.cs
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentRow.cs
@@ -1,0 +1,28 @@
+using Serenity.Workflow;
+
+namespace Serene.Documents;
+
+[ConnectionKey("Default"), Module("Documents"), TableName("Documents")]
+[DisplayName("Documents"), InstanceName("Document")]
+[ReadPermission("Document:View")]
+[ModifyPermission("Document:Modify")]
+[WorkflowEnabled("DocumentWorkflow")]
+public sealed class DocumentRow : Row<DocumentRow.RowFields>, IIdRow, INameRow
+{
+    [DisplayName("Document Id"), Identity, IdProperty]
+    public int? DocumentId { get => fields.DocumentId[this]; set => fields.DocumentId[this] = value; }
+
+    [DisplayName("Title"), Size(100), NotNull, QuickSearch, NameProperty]
+    public string Title { get => fields.Title[this]; set => fields.Title[this] = value; }
+
+    [DisplayName("State"), Size(50), NotNull]
+    [WorkflowStateField]
+    public string State { get => fields.State[this]; set => fields.State[this] = value; }
+
+    public class RowFields : RowFieldsBase
+    {
+        public Int32Field DocumentId;
+        public StringField Title;
+        public StringField State;
+    }
+}

--- a/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentDeleteHandler.cs
+++ b/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentDeleteHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Documents.DocumentRow;
+using MyRequest = Serenity.Services.DeleteRequest;
+using MyResponse = Serenity.Services.DeleteResponse;
+
+namespace Serene.Documents;
+
+public interface IDocumentDeleteHandler : IDeleteHandler<MyRow, MyRequest, MyResponse> { }
+
+public class DocumentDeleteHandler(IRequestContext context)
+    : DeleteRequestHandler<MyRow, MyRequest, MyResponse>(context), IDocumentDeleteHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentListHandler.cs
+++ b/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentListHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Documents.DocumentRow;
+using MyRequest = Serenity.Services.ListRequest;
+using MyResponse = Serenity.Services.ListResponse<Serene.Documents.DocumentRow>;
+
+namespace Serene.Documents;
+
+public interface IDocumentListHandler : IListHandler<MyRow, MyRequest, MyResponse> { }
+
+public class DocumentListHandler(IRequestContext context)
+    : ListRequestHandler<MyRow, MyRequest, MyResponse>(context), IDocumentListHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentRetrieveHandler.cs
+++ b/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentRetrieveHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Documents.DocumentRow;
+using MyRequest = Serenity.Services.RetrieveRequest;
+using MyResponse = Serenity.Services.RetrieveResponse<Serene.Documents.DocumentRow>;
+
+namespace Serene.Documents;
+
+public interface IDocumentRetrieveHandler : IRetrieveHandler<MyRow, MyRequest, MyResponse> { }
+
+public class DocumentRetrieveHandler(IRequestContext context)
+    : RetrieveRequestHandler<MyRow, MyRequest, MyResponse>(context), IDocumentRetrieveHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentSaveHandler.cs
+++ b/serene/src/Serene.Web/Modules/Documents/RequestHandlers/DocumentSaveHandler.cs
@@ -1,0 +1,12 @@
+using MyRow = Serene.Documents.DocumentRow;
+using MyRequest = Serenity.Services.SaveRequest<Serene.Documents.DocumentRow>;
+using MyResponse = Serenity.Services.SaveResponse;
+
+namespace Serene.Documents;
+
+public interface IDocumentSaveHandler : ISaveHandler<MyRow, MyRequest, MyResponse> { }
+
+public class DocumentSaveHandler(IRequestContext context)
+    : SaveRequestHandler<MyRow, MyRequest, MyResponse>(context), IDocumentSaveHandler
+{
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Documents.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Documents.ts
@@ -1,0 +1,4 @@
+export * from "./Documents/DocumentColumns"
+export * from "./Documents/DocumentForm"
+export * from "./Documents/DocumentRow"
+export * from "./Documents/DocumentService"

--- a/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentColumns.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentColumns.ts
@@ -1,0 +1,13 @@
+import { ColumnsBase, fieldsProxy } from "@serenity-is/corelib";
+import { Column } from "@serenity-is/sleekgrid";
+import { DocumentRow } from "./DocumentRow";
+
+export interface DocumentColumns {
+    Title: Column<DocumentRow>;
+    State: Column<DocumentRow>;
+}
+
+export class DocumentColumns extends ColumnsBase<DocumentRow> {
+    static readonly columnsKey = 'Documents.Document';
+    static readonly Fields = fieldsProxy<DocumentColumns>();
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentForm.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentForm.ts
@@ -1,0 +1,26 @@
+import { StringEditor, PrefixedContext, initFormType } from "@serenity-is/corelib";
+
+export interface DocumentForm {
+    Title: StringEditor;
+    State: StringEditor;
+}
+
+export class DocumentForm extends PrefixedContext {
+    static readonly formKey = 'Documents.Document';
+    private static init: boolean;
+
+    constructor(prefix: string) {
+        super(prefix);
+
+        if (!DocumentForm.init)  {
+            DocumentForm.init = true;
+
+            var w0 = StringEditor;
+
+            initFormType(DocumentForm, [
+                'Title', w0,
+                'State', w0
+            ]);
+        }
+    }
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentRow.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentRow.ts
@@ -1,0 +1,19 @@
+﻿import { fieldsProxy } from "@serenity-is/corelib";
+
+export interface DocumentRow {
+    DocumentId?: number;
+    Title?: string;
+    State?: string;
+}
+
+export abstract class DocumentRow {
+    static readonly idProperty = 'DocumentId';
+    static readonly nameProperty = 'Title';
+    static readonly localTextPrefix = 'Documents.Document';
+    static readonly deletePermission = 'Document:Modify';
+    static readonly insertPermission = 'Document:Modify';
+    static readonly readPermission = 'Document:View';
+    static readonly updatePermission = 'Document:Modify';
+
+    static readonly Fields = fieldsProxy<DocumentRow>();
+}

--- a/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentService.ts
+++ b/serene/src/Serene.Web/Modules/ServerTypes/Documents/DocumentService.ts
@@ -1,0 +1,32 @@
+﻿import { SaveRequest, SaveResponse, ServiceOptions, DeleteRequest, DeleteResponse, RetrieveRequest, RetrieveResponse, ListRequest, ListResponse, serviceRequest } from "@serenity-is/corelib";
+import { DocumentRow } from "./DocumentRow";
+
+export namespace DocumentService {
+    export const baseUrl = 'Documents/Document';
+
+    export declare function Create(request: SaveRequest<DocumentRow>, onSuccess?: (response: SaveResponse) => void, opt?: ServiceOptions<any>): PromiseLike<SaveResponse>;
+    export declare function Update(request: SaveRequest<DocumentRow>, onSuccess?: (response: SaveResponse) => void, opt?: ServiceOptions<any>): PromiseLike<SaveResponse>;
+    export declare function Delete(request: DeleteRequest, onSuccess?: (response: DeleteResponse) => void, opt?: ServiceOptions<any>): PromiseLike<DeleteResponse>;
+    export declare function Retrieve(request: RetrieveRequest, onSuccess?: (response: RetrieveResponse<DocumentRow>) => void, opt?: ServiceOptions<any>): PromiseLike<RetrieveResponse<DocumentRow>>;
+    export declare function List(request: ListRequest, onSuccess?: (response: ListResponse<DocumentRow>) => void, opt?: ServiceOptions<any>): PromiseLike<ListResponse<DocumentRow>>;
+
+    export const Methods = {
+        Create: "Documents/Document/Create",
+        Update: "Documents/Document/Update",
+        Delete: "Documents/Document/Delete",
+        Retrieve: "Documents/Document/Retrieve",
+        List: "Documents/Document/List"
+    } as const;
+
+    [
+        'Create', 
+        'Update', 
+        'Delete', 
+        'Retrieve', 
+        'List'
+    ].forEach(x => {
+        (<any>DocumentService)[x] = function (r, s, o) {
+            return serviceRequest(baseUrl + '/' + x, r, s, o);
+        };
+    });
+}

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/ApproveDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/ApproveDocumentWorkflowHandler.cs
@@ -1,14 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Serenity.Data;
 using Serenity.Workflow;
 
 namespace Serene.Workflow;
 
-public class ApproveDocumentWorkflowHandler : IWorkflowActionHandler
+public class ApproveDocumentWorkflowHandler(ISqlConnections connections) : IWorkflowActionHandler
 {
     public Task ExecuteAsync(IServiceProvider services, object instance, IDictionary<string, object?>? input)
     {
+        if (input is null || !input.TryGetValue("EntityId", out var id) || id is null)
+            return Task.CompletedTask;
+
+        var documentId = Convert.ToInt32(id);
+        using var connection = connections.NewByKey("Default");
+        var fields = Documents.DocumentRow.Fields;
+        new SqlUpdate(fields.TableName)
+            .Set(fields.State, "Approved")
+            .Where(fields.DocumentId == documentId)
+            .Execute(connection);
+
         return Task.CompletedTask;
     }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/RejectDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/RejectDocumentWorkflowHandler.cs
@@ -1,14 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Serenity.Data;
 using Serenity.Workflow;
 
 namespace Serene.Workflow;
 
-public class RejectDocumentWorkflowHandler : IWorkflowActionHandler
+public class RejectDocumentWorkflowHandler(ISqlConnections connections) : IWorkflowActionHandler
 {
     public Task ExecuteAsync(IServiceProvider services, object instance, IDictionary<string, object?>? input)
     {
+        if (input is null || !input.TryGetValue("EntityId", out var id) || id is null)
+            return Task.CompletedTask;
+
+        var documentId = Convert.ToInt32(id);
+        using var connection = connections.NewByKey("Default");
+        var fields = Documents.DocumentRow.Fields;
+        new SqlUpdate(fields.TableName)
+            .Set(fields.State, "Rejected")
+            .Where(fields.DocumentId == documentId)
+            .Execute(connection);
+
         return Task.CompletedTask;
     }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/RequestChangesDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/RequestChangesDocumentWorkflowHandler.cs
@@ -1,14 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Serenity.Data;
 using Serenity.Workflow;
 
 namespace Serene.Workflow;
 
-public class RequestChangesDocumentWorkflowHandler : IWorkflowActionHandler
+public class RequestChangesDocumentWorkflowHandler(ISqlConnections connections) : IWorkflowActionHandler
 {
     public Task ExecuteAsync(IServiceProvider services, object instance, IDictionary<string, object?>? input)
     {
+        if (input is null || !input.TryGetValue("EntityId", out var id) || id is null)
+            return Task.CompletedTask;
+
+        var documentId = Convert.ToInt32(id);
+        using var connection = connections.NewByKey("Default");
+        var fields = Documents.DocumentRow.Fields;
+        new SqlUpdate(fields.TableName)
+            .Set(fields.State, "ChangesRequested")
+            .Where(fields.DocumentId == documentId)
+            .Execute(connection);
+
         return Task.CompletedTask;
     }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/ResubmitDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/ResubmitDocumentWorkflowHandler.cs
@@ -1,14 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Serenity.Data;
 using Serenity.Workflow;
 
 namespace Serene.Workflow;
 
-public class ResubmitDocumentWorkflowHandler : IWorkflowActionHandler
+public class ResubmitDocumentWorkflowHandler(ISqlConnections connections) : IWorkflowActionHandler
 {
     public Task ExecuteAsync(IServiceProvider services, object instance, IDictionary<string, object?>? input)
     {
+        if (input is null || !input.TryGetValue("EntityId", out var id) || id is null)
+            return Task.CompletedTask;
+
+        var documentId = Convert.ToInt32(id);
+        using var connection = connections.NewByKey("Default");
+        var fields = Documents.DocumentRow.Fields;
+        new SqlUpdate(fields.TableName)
+            .Set(fields.State, "Resubmitted")
+            .Where(fields.DocumentId == documentId)
+            .Execute(connection);
+
         return Task.CompletedTask;
     }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/StartFinalReviewDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/StartFinalReviewDocumentWorkflowHandler.cs
@@ -1,14 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Serenity.Data;
 using Serenity.Workflow;
 
 namespace Serene.Workflow;
 
-public class StartFinalReviewDocumentWorkflowHandler : IWorkflowActionHandler
+public class StartFinalReviewDocumentWorkflowHandler(ISqlConnections connections) : IWorkflowActionHandler
 {
     public Task ExecuteAsync(IServiceProvider services, object instance, IDictionary<string, object?>? input)
     {
+        if (input is null || !input.TryGetValue("EntityId", out var id) || id is null)
+            return Task.CompletedTask;
+
+        var documentId = Convert.ToInt32(id);
+        using var connection = connections.NewByKey("Default");
+        var fields = Documents.DocumentRow.Fields;
+        new SqlUpdate(fields.TableName)
+            .Set(fields.State, "FinalReview")
+            .Where(fields.DocumentId == documentId)
+            .Execute(connection);
+
         return Task.CompletedTask;
     }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/StartReviewDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/StartReviewDocumentWorkflowHandler.cs
@@ -1,14 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Serenity.Data;
 using Serenity.Workflow;
 
 namespace Serene.Workflow;
 
-public class StartReviewDocumentWorkflowHandler : IWorkflowActionHandler
+public class StartReviewDocumentWorkflowHandler(ISqlConnections connections) : IWorkflowActionHandler
 {
     public Task ExecuteAsync(IServiceProvider services, object instance, IDictionary<string, object?>? input)
     {
+        if (input is null || !input.TryGetValue("EntityId", out var id) || id is null)
+            return Task.CompletedTask;
+
+        var documentId = Convert.ToInt32(id);
+        using var connection = connections.NewByKey("Default");
+        var fields = Documents.DocumentRow.Fields;
+        new SqlUpdate(fields.TableName)
+            .Set(fields.State, "UnderReview")
+            .Where(fields.DocumentId == documentId)
+            .Execute(connection);
+
         return Task.CompletedTask;
     }
 }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/SubmitDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/SubmitDocumentWorkflowHandler.cs
@@ -1,14 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Serenity.Data;
 using Serenity.Workflow;
 
 namespace Serene.Workflow;
 
-public class SubmitDocumentWorkflowHandler : IWorkflowActionHandler
+public class SubmitDocumentWorkflowHandler(ISqlConnections connections) : IWorkflowActionHandler
 {
     public Task ExecuteAsync(IServiceProvider services, object instance, IDictionary<string, object?>? input)
     {
+        if (input is null || !input.TryGetValue("EntityId", out var id) || id is null)
+            return Task.CompletedTask;
+
+        var documentId = Convert.ToInt32(id);
+        using var connection = connections.NewByKey("Default");
+        var fields = Documents.DocumentRow.Fields;
+        new SqlUpdate(fields.TableName)
+            .Set(fields.State, "Submitted")
+            .Where(fields.DocumentId == documentId)
+            .Execute(connection);
+
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- add Documents table via migration
- implement Document module with pages, handlers and client scripts
- create TypeScript server types for Documents
- implement handlers for DocumentWorkflow transitions

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d8734838832eb9e9b72527d6bb15