### PR TITLE
Fix dynamic data form key for workflow trigger

### DIFF
--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.ts
@@ -65,8 +65,13 @@ export abstract class WorkflowEntityDialog<TItem, TOptions> extends EntityDialog
         };
 
         if (trigger?.RequiresInput && trigger.FormKey) {
-            const dlg = new PropertyDialog<any, any>();
-            (dlg as any).getFormKey = () => trigger.FormKey!;
+            class TriggerDialog extends PropertyDialog<any, any> {
+                constructor(private triggerFormKey: string) {
+                    super();
+                }
+                protected override getFormKey() { return this.triggerFormKey; }
+            }
+            const dlg = new TriggerDialog(trigger.FormKey);
             dlg.dialogTitle = trigger.DisplayName || trigger.TriggerKey;
             dlg.dialogOpen();
             dlg.onClose((r: string) => {


### PR DESCRIPTION
## Summary
- ensure property dialog uses workflow trigger's form key when opening dialogs

## Testing
- `pnpm -r test` *(fails: Cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6841e1942df4832e9a0609afb259b964