### PR TITLE
Fix WorkflowHistoryDialog base type

### DIFF
--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryDialog.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryDialog.ts
@@ -1,8 +1,8 @@
-import { Dialog, Decorators } from "@serenity-is/corelib";
+import { BaseDialog, Decorators } from "@serenity-is/corelib";
 import { WorkflowService, GetWorkflowHistoryRequest } from "./WorkflowService";
 
 @Decorators.registerClass('Serene.Workflow.WorkflowHistoryDialog')
-export class WorkflowHistoryDialog extends Dialog<GetWorkflowHistoryRequest, any> {
+export class WorkflowHistoryDialog extends BaseDialog<GetWorkflowHistoryRequest> {
     private grid: HTMLTableElement;
 
     constructor() {
@@ -10,6 +10,11 @@ export class WorkflowHistoryDialog extends Dialog<GetWorkflowHistoryRequest, any
         this.dialogTitle = 'Workflow History';
         this.grid = document.createElement('table');
         this.element.appendChild(this.grid);
+    }
+
+    public loadAndOpenDialog(request: GetWorkflowHistoryRequest, asPanel?: boolean) {
+        Object.assign(this.options as any, request);
+        this.dialogOpen(asPanel);
     }
 
     protected async onDialogOpen() {


### PR DESCRIPTION
## Summary
- use BaseDialog instead of the generic Dialog for workflow history
- add method to load options before opening the dialog

## Testing
- `pnpm -r build` *(fails: Cannot find package 'esbuild')*
- `pnpm -r test` *(fails: Cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6841e53752cc832e87957a1a55af424f