### PR TITLE
Improve workflow history table styling

### DIFF
--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryDialog.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryDialog.ts
@@ -9,6 +9,10 @@ export class WorkflowHistoryDialog extends BaseDialog<GetWorkflowHistoryRequest>
         super();
         this.dialogTitle = 'Workflow History';
         this.grid = document.createElement('table');
+        this.grid.classList.add('table', 'table-striped', 'table-bordered', 'workflow-history-grid');
+        const header = document.createElement('thead');
+        header.innerHTML = `<tr><th>Date</th><th>From State</th><th>To State</th><th>Trigger</th></tr>`;
+        this.grid.appendChild(header);
         this.element.appendChild(this.grid);
     }
 

--- a/serene/src/Serene.Web/wwwroot/Content/site/site.css
+++ b/serene/src/Serene.Web/wwwroot/Content/site/site.css
@@ -11,3 +11,19 @@
 .s-PermissionCheckEditor {
   min-height: 450px;
 }
+
+.workflow-history-grid {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.workflow-history-grid td,
+.workflow-history-grid th {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+}
+
+.workflow-history-grid thead {
+  background-color: var(--bs-secondary-bg, #f8f9fa);
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- apply bootstrap table styling to WorkflowHistoryDialog
- add workflow-history-grid CSS class for table layout

## Testing
- `pnpm -r test` *(fails: Cannot find package 'esbuild')*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e8113dd0832e98b85023ba7ccb4f