### PR TITLE
Show workflow input in history

### DIFF
--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryDialog.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryDialog.ts
@@ -11,7 +11,7 @@ export class WorkflowHistoryDialog extends BaseDialog<GetWorkflowHistoryRequest>
         this.grid = document.createElement('table');
         this.grid.classList.add('table', 'table-striped', 'table-bordered', 'workflow-history-grid');
         const header = document.createElement('thead');
-        header.innerHTML = `<tr><th>Date</th><th>From State</th><th>To State</th><th>Trigger</th></tr>`;
+        header.innerHTML = `<tr><th>Date</th><th>From State</th><th>To State</th><th>Trigger</th><th>Input</th></tr>`;
         this.grid.appendChild(header);
         this.element.append(this.grid);
     }
@@ -28,7 +28,8 @@ export class WorkflowHistoryDialog extends BaseDialog<GetWorkflowHistoryRequest>
         const body = document.createElement('tbody');
         for (const h of r.History ?? []) {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${h.EventDate}</td><td>${h.FromState}</td><td>${h.ToState}</td><td>${h.Trigger}</td>`;
+            const inputText = h.Input ? JSON.stringify(h.Input) : '';
+            tr.innerHTML = `<td>${h.EventDate}</td><td>${h.FromState}</td><td>${h.ToState}</td><td>${h.Trigger}</td><td>${inputText}</td>`;
             body.appendChild(tr);
         }
         this.grid.appendChild(body);

--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowService.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowService.ts
@@ -52,6 +52,7 @@ export interface GetWorkflowHistoryResponse extends ServiceResponse {
         FromState: string;
         ToState: string;
         Trigger: string;
+        Input?: any;
         EventDate: string;
         User?: string;
     }[];

--- a/src/Serenity.Workflow.Abstractions/Engine/WorkflowHistoryEntry.cs
+++ b/src/Serenity.Workflow.Abstractions/Engine/WorkflowHistoryEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 namespace Serenity.Workflow;
 
 public class WorkflowHistoryEntry
@@ -8,6 +9,7 @@ public class WorkflowHistoryEntry
     public required string FromState { get; set; }
     public required string ToState { get; set; }
     public required string Trigger { get; set; }
+    public IDictionary<string, object?>? Input { get; set; }
     public DateTime EventDate { get; set; } = DateTime.UtcNow;
     public string? User { get; set; }
 }

--- a/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
+++ b/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Stateless;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Serenity.Workflow
@@ -91,13 +92,17 @@ namespace Serenity.Workflow
                 entityId = val;
             if (entityId != null)
             {
+                IDictionary<string, object?>? historyInput = input == null ? null :
+                    new Dictionary<string, object?>(input);
+                historyInput?.Remove("EntityId");
                 historyStore.RecordEntry(new WorkflowHistoryEntry
                 {
                     WorkflowKey = workflowKey,
                     EntityId = entityId,
                     FromState = from,
                     ToState = to,
-                    Trigger = trigger
+                    Trigger = trigger,
+                    Input = historyInput
                 });
             }
         }


### PR DESCRIPTION
## Summary
- keep track of input in `WorkflowHistoryEntry`
- propagate input logging in `WorkflowEngine`
- expose `Input` field to TypeScript service models
- display collected input on `WorkflowHistoryDialog`

## Testing
- `pnpm -r test` *(fails: Cannot find package 'esbuild' imported from build.js)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1c82868832e8f65b71abd5041e6