### PR TITLE
Modernize network calls

### DIFF
--- a/common-features/src/extensions/Modules/ClamAV/ClamAVUploadScanner.cs
+++ b/common-features/src/extensions/Modules/ClamAV/ClamAVUploadScanner.cs
@@ -49,7 +49,7 @@ public class ClamAVUploadScanner(IOptionsMonitor<ClamAVSettings> options,
 
             var clam = new ClamClient(host, port);
 
-            var scanResult = Task.Run(() => clam.SendAndScanFileAsync(stream)).Result;
+            var scanResult = clam.SendAndScanFileAsync(stream).GetAwaiter().GetResult();
 
             switch (scanResult.Result)
             {

--- a/src/Serenity.Net.Web/Security/RecaptchaValidation.cs
+++ b/src/Serenity.Net.Web/Security/RecaptchaValidation.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
+using System.Text.Json.Serialization;
 
 namespace Serenity.Web;
 
@@ -19,37 +22,31 @@ public static class RecaptchaValidation
     /// <remarks>Inspired from https://github.com/tanveery/recaptcha-net/blob/master/src/Recaptcha.Web/RecaptchaVerificationHelper.cs</remarks>
     public static void Validate(string secretKey, string token, ITextLocalizer localizer)
     {
+        ValidateAsync(secretKey, token, localizer).GetAwaiter().GetResult();
+    }
+
+    public static async Task ValidateAsync(string secretKey, string token, ITextLocalizer localizer)
+    {
         if (string.IsNullOrEmpty(token))
             throw new ValidationError("Recaptcha", localizer.Get("Validation.Recaptcha"));
 
-        var postData = string.Format(CultureInfo.InvariantCulture, "secret={0}&response={1}",
-            Uri.EscapeDataString(secretKey),
-            Uri.EscapeDataString(token));
+        var values = new Dictionary<string, string>
+        {
+            ["secret"] = secretKey,
+            ["response"] = token
+        };
 
-        byte[] postDataBuffer = System.Text.Encoding.ASCII.GetBytes(postData);
-        var verifyUri = new Uri("https://www.google.com/recaptcha/api/siteverify", UriKind.Absolute);
+        var content = new FormUrlEncodedContent(values);
+        using var httpClient = new HttpClient();
+        using var response = await httpClient.PostAsync("https://www.google.com/recaptcha/api/siteverify", content);
+        var responseJson = await response.Content.ReadAsStringAsync();
 
-#pragma warning disable SYSLIB0014
-        var webRequest = (HttpWebRequest)WebRequest.Create(verifyUri);
-        webRequest.ContentType = "application/x-www-form-urlencoded";
-        webRequest.Headers["Content-Length"] = postDataBuffer.Length.ToString(CultureInfo.InvariantCulture);
-
-        webRequest.Method = "POST";
-        using (var requestStream = Task.Run(webRequest.GetRequestStreamAsync).Result)
-            requestStream.Write(postDataBuffer, 0, postDataBuffer.Length);
-
-        using var webResponse = Task.Run(webRequest.GetResponseAsync).Result;
-        string responseJson;
-        using (var sr = new StreamReader(webResponse.GetResponseStream()))
-            responseJson = sr.ReadToEnd();
-
-        var response = JSON.ParseTolerant<RecaptchaResponse>(responseJson);
-        if (response == null ||
-            !response.Success)
+        var recaptchaResponse = JSON.ParseTolerant<RecaptchaResponse>(responseJson);
+        if (recaptchaResponse == null ||
+            !recaptchaResponse.Success)
         {
             throw new ValidationError("Recaptcha", localizer.Get("Validation.Recaptcha"));
         }
-#pragma warning restore SYSLIB0014
     }
 
     private class RecaptchaResponse


### PR DESCRIPTION
## Summary
- replace HttpWebRequest patterns with HttpClient
- introduce async APIs for `JsonServiceClient` and `RecaptchaValidation`
- streamline ClamAV scanner to avoid Task.Run

## Testing
- `pnpm test -r` *(fails: Cannot find package 'esbuild')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483a0c5968832e8004f28a59f00ef5