### PR TITLE
Add StepWizard widget and sample page

### DIFF
--- a/packages/corelib/src/index.ts
+++ b/packages/corelib/src/index.ts
@@ -96,5 +96,6 @@ export * from "./ui/datagrid/entitygrid";
 export * from "./ui/dialogs/entitytoolbuttons";
 export * from "./ui/dialogs/entitylocalizer";
 export * from "./ui/dialogs/entitydialog";
+export * from "./ui/widgets/stepwizard";
 
 export type Constructor<T> = new (...args: any[]) => T;

--- a/packages/corelib/src/ui/widgets/stepwizard.tsx
+++ b/packages/corelib/src/ui/widgets/stepwizard.tsx
@@ -1,0 +1,54 @@
+import { Fluent } from "../../base";
+import { Decorators } from "../../types/decorators";
+import { Widget, WidgetProps } from "./widget";
+
+export interface StepWizardOptions {
+    startStep?: number;
+}
+
+@Decorators.registerClass('Serenity.StepWizard')
+export class StepWizard<P extends StepWizardOptions = StepWizardOptions> extends Widget<P> {
+    protected steps: HTMLElement[] = [];
+    protected index = 0;
+    protected toolbar: HTMLElement;
+    protected prevBtn: HTMLButtonElement;
+    protected nextBtn: HTMLButtonElement;
+    protected content: HTMLElement;
+
+    protected renderContents() {
+        this.domNode.classList.add('s-StepWizard');
+        this.steps = Array.from(this.domNode.querySelectorAll<HTMLElement>('.step-pane'));
+        this.index = this.options.startStep ?? 0;
+        this.content = this.domNode.appendChild(<div class="wizard-content" />);
+        this.toolbar = this.domNode.appendChild(<div class="wizard-toolbar btn-group" />);
+        this.prevBtn = this.toolbar.appendChild(<button type="button" class="btn btn-secondary">Back</button>);
+        this.nextBtn = this.toolbar.appendChild(<button type="button" class="btn btn-primary">Next</button>);
+        this.prevBtn.addEventListener('click', () => this.previous());
+        this.nextBtn.addEventListener('click', () => this.next());
+        this.showStep(this.index);
+    }
+
+    protected showStep(i: number) {
+        this.content.innerHTML = '';
+        if (this.steps[i])
+            this.content.appendChild(this.steps[i]);
+        this.prevBtn.disabled = i === 0;
+        this.nextBtn.textContent = i >= this.steps.length - 1 ? 'Finish' : 'Next';
+    }
+
+    next() {
+        if (this.index < this.steps.length - 1) {
+            this.index++;
+            this.showStep(this.index);
+        } else {
+            Fluent.trigger(this.domNode, 'finish');
+        }
+    }
+
+    previous() {
+        if (this.index > 0) {
+            this.index--;
+            this.showStep(this.index);
+        }
+    }
+}

--- a/serene/src/Serene.Web/Areas/Samples/StepWizard/Index.cshtml
+++ b/serene/src/Serene.Web/Areas/Samples/StepWizard/Index.cshtml
@@ -1,0 +1,15 @@
+@{
+    ViewData["Title"] = "Step Wizard";
+}
+
+@section ContentHeader {
+    <h1>Step Wizard</h1>
+}
+
+<div id="PanelDiv" class="s-Panel">
+    <div class="step-pane">This is step 1</div>
+    <div class="step-pane">This is step 2</div>
+    <div class="step-pane">This is step 3</div>
+</div>
+
+@Html.ModulePageInit(ESM.StepWizardPage)

--- a/serene/src/Serene.Web/Imports/MVC/ESM.cs
+++ b/serene/src/Serene.Web/Imports/MVC/ESM.cs
@@ -9,6 +9,7 @@ public static partial class ESM
     public const string ScriptInit = "~/esm/Modules/Common/ScriptInit.js";
     public const string SignUpPage = "~/esm/Modules/Membership/Account/SignUp/SignUpPage.js";
     public const string TaskItemPage = "~/esm/Modules/Tasks/TaskItemPage.js";
+    public const string StepWizardPage = "~/esm/Modules/Samples/StepWizard/StepWizardPage.js";
     public const string TranslationPage = "~/esm/Modules/Administration/Translation/TranslationPage.js";
     public const string UserPage = "~/esm/Modules/Administration/User/UserPage.js";
 
@@ -66,6 +67,11 @@ public static partial class ESM
         public static partial class Tasks
         {
             public const string TaskItemPage = "~/esm/Modules/Tasks/TaskItemPage.js";
+        }
+
+        public static partial class Samples
+        {
+            public const string StepWizardPage = "~/esm/Modules/Samples/StepWizard/StepWizardPage.js";
         }
     }
 }

--- a/serene/src/Serene.Web/Modules/Samples/StepWizard/StepWizardNavigation.cs
+++ b/serene/src/Serene.Web/Modules/Samples/StepWizard/StepWizardNavigation.cs
@@ -1,0 +1,5 @@
+using SamplesPages = Serene.Samples.Pages;
+
+[assembly: NavigationMenu(11000, "Samples", icon: "fa-magic")]
+[assembly: NavigationLink(11010, "Samples/Step Wizard", typeof(SamplesPages.StepWizardPage), icon: "fa-magic")]
+

--- a/serene/src/Serene.Web/Modules/Samples/StepWizard/StepWizardPage.cs
+++ b/serene/src/Serene.Web/Modules/Samples/StepWizard/StepWizardPage.cs
@@ -1,0 +1,11 @@
+namespace Serene.Samples.Pages;
+
+[Route("Samples/StepWizard")]
+public class StepWizardPage : Controller
+{
+    [PageAuthorize]
+    public ActionResult Index()
+    {
+        return View("~/Areas/Samples/StepWizard/Index.cshtml");
+    }
+}

--- a/serene/src/Serene.Web/Modules/Samples/StepWizard/StepWizardPage.ts
+++ b/serene/src/Serene.Web/Modules/Samples/StepWizard/StepWizardPage.ts
@@ -1,0 +1,4 @@
+import { panelPageInit } from "@serenity-is/corelib";
+import { StepWizard } from "@serenity-is/corelib";
+
+export default () => panelPageInit(StepWizard);


### PR DESCRIPTION
## Summary
- implement new `StepWizard` widget for sequential forms
- export `StepWizard` from corelib index
- integrate StepWizard page in sample app with navigation and view
- register `StepWizardPage` in ESM imports

## Testing
- `pnpm -r build` *(fails: Cannot find package 'esbuild')*
- `pnpm -r test` *(fails: Cannot find package 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_684aa0b6cb60832ebd36e3d57d640369