### PR TITLE
Add workflow trigger validation

### DIFF
--- a/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
+++ b/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
@@ -74,9 +74,21 @@ namespace Serenity.Workflow
             ArgumentNullException.ThrowIfNull(currentState);
             ArgumentNullException.ThrowIfNull(trigger);
 
+            var def = definitionProvider.GetDefinition(workflowKey) ??
+                throw new InvalidOperationException($"Workflow {workflowKey} not found");
+
+            if (!def.Triggers.ContainsKey(trigger))
+                throw new InvalidOperationException($"Trigger '{trigger}' is not defined for workflow '{workflowKey}'");
+
+            if (!def.States.ContainsKey(currentState))
+                throw new InvalidOperationException($"State '{currentState}' is not defined for workflow '{workflowKey}'");
+
             var machine = CreateMachine(workflowKey, currentState);
+            if (!machine.CanFire(trigger))
+                throw new InvalidOperationException($"Trigger '{trigger}' cannot be fired from state '{currentState}' for workflow '{workflowKey}'");
+
             WorkflowTrigger? action = null;
-            definitionProvider.GetDefinition(workflowKey)?.Triggers.TryGetValue(trigger, out action);
+            def.Triggers.TryGetValue(trigger, out action);
 
             IWorkflowActionHandler? handler = null;
             if (action?.HandlerKey != null)


### PR DESCRIPTION
## Summary
- validate workflow triggers and states in WorkflowEngine
- expand workflow engine tests to cover invalid triggers and disallowed states

## Testing
- `dotnet test tests/Serenity.Net.Tests/Serenity.Net.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684c42bfc770832e97c85f3576aef3c4