### PR TITLE
Implement concurrency check for workflow actions

### DIFF
--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/ApproveDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/ApproveDocumentWorkflowHandler.cs
@@ -16,10 +16,15 @@ public class ApproveDocumentWorkflowHandler(ISqlConnections connections) : IWork
         var documentId = Convert.ToInt32(id);
         using var connection = connections.NewByKey("Default");
         var fields = Documents.DocumentRow.Fields;
-        new SqlUpdate(fields.TableName)
+        input.TryGetValue("CurrentState", out var cs);
+        var update = new SqlUpdate(fields.TableName)
             .Set(fields.State, "Approved")
-            .Where(fields.DocumentId == documentId)
-            .Execute(connection);
+            .Where(fields.DocumentId == documentId);
+        if (cs is string state)
+            update.Where(fields.State == state);
+        var rows = update.Execute(connection, ExpectedRows.ZeroOrOne);
+        if (rows == 0)
+            throw new InvalidOperationException("Concurrent modification detected");
 
         return Task.CompletedTask;
     }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/RejectDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/RejectDocumentWorkflowHandler.cs
@@ -16,10 +16,15 @@ public class RejectDocumentWorkflowHandler(ISqlConnections connections) : IWorkf
         var documentId = Convert.ToInt32(id);
         using var connection = connections.NewByKey("Default");
         var fields = Documents.DocumentRow.Fields;
-        new SqlUpdate(fields.TableName)
+        input.TryGetValue("CurrentState", out var cs);
+        var update = new SqlUpdate(fields.TableName)
             .Set(fields.State, "Rejected")
-            .Where(fields.DocumentId == documentId)
-            .Execute(connection);
+            .Where(fields.DocumentId == documentId);
+        if (cs is string state)
+            update.Where(fields.State == state);
+        var rows = update.Execute(connection, ExpectedRows.ZeroOrOne);
+        if (rows == 0)
+            throw new InvalidOperationException("Concurrent modification detected");
 
         return Task.CompletedTask;
     }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/RequestChangesDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/RequestChangesDocumentWorkflowHandler.cs
@@ -16,10 +16,15 @@ public class RequestChangesDocumentWorkflowHandler(ISqlConnections connections) 
         var documentId = Convert.ToInt32(id);
         using var connection = connections.NewByKey("Default");
         var fields = Documents.DocumentRow.Fields;
-        new SqlUpdate(fields.TableName)
+        input.TryGetValue("CurrentState", out var cs);
+        var update = new SqlUpdate(fields.TableName)
             .Set(fields.State, "ChangesRequested")
-            .Where(fields.DocumentId == documentId)
-            .Execute(connection);
+            .Where(fields.DocumentId == documentId);
+        if (cs is string state)
+            update.Where(fields.State == state);
+        var rows = update.Execute(connection, ExpectedRows.ZeroOrOne);
+        if (rows == 0)
+            throw new InvalidOperationException("Concurrent modification detected");
 
         return Task.CompletedTask;
     }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/ResubmitDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/ResubmitDocumentWorkflowHandler.cs
@@ -16,10 +16,15 @@ public class ResubmitDocumentWorkflowHandler(ISqlConnections connections) : IWor
         var documentId = Convert.ToInt32(id);
         using var connection = connections.NewByKey("Default");
         var fields = Documents.DocumentRow.Fields;
-        new SqlUpdate(fields.TableName)
+        input.TryGetValue("CurrentState", out var cs);
+        var update = new SqlUpdate(fields.TableName)
             .Set(fields.State, "Resubmitted")
-            .Where(fields.DocumentId == documentId)
-            .Execute(connection);
+            .Where(fields.DocumentId == documentId);
+        if (cs is string state)
+            update.Where(fields.State == state);
+        var rows = update.Execute(connection, ExpectedRows.ZeroOrOne);
+        if (rows == 0)
+            throw new InvalidOperationException("Concurrent modification detected");
 
         return Task.CompletedTask;
     }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/StartFinalReviewDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/StartFinalReviewDocumentWorkflowHandler.cs
@@ -16,10 +16,15 @@ public class StartFinalReviewDocumentWorkflowHandler(ISqlConnections connections
         var documentId = Convert.ToInt32(id);
         using var connection = connections.NewByKey("Default");
         var fields = Documents.DocumentRow.Fields;
-        new SqlUpdate(fields.TableName)
+        input.TryGetValue("CurrentState", out var cs);
+        var update = new SqlUpdate(fields.TableName)
             .Set(fields.State, "FinalReview")
-            .Where(fields.DocumentId == documentId)
-            .Execute(connection);
+            .Where(fields.DocumentId == documentId);
+        if (cs is string state)
+            update.Where(fields.State == state);
+        var rows = update.Execute(connection, ExpectedRows.ZeroOrOne);
+        if (rows == 0)
+            throw new InvalidOperationException("Concurrent modification detected");
 
         return Task.CompletedTask;
     }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/StartReviewDocumentWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/StartReviewDocumentWorkflowHandler.cs
@@ -16,10 +16,15 @@ public class StartReviewDocumentWorkflowHandler(ISqlConnections connections) : I
         var documentId = Convert.ToInt32(id);
         using var connection = connections.NewByKey("Default");
         var fields = Documents.DocumentRow.Fields;
-        new SqlUpdate(fields.TableName)
+        input.TryGetValue("CurrentState", out var cs);
+        var update = new SqlUpdate(fields.TableName)
             .Set(fields.State, "UnderReview")
-            .Where(fields.DocumentId == documentId)
-            .Execute(connection);
+            .Where(fields.DocumentId == documentId);
+        if (cs is string state)
+            update.Where(fields.State == state);
+        var rows = update.Execute(connection, ExpectedRows.ZeroOrOne);
+        if (rows == 0)
+            throw new InvalidOperationException("Concurrent modification detected");
 
         return Task.CompletedTask;
     }

--- a/serene/src/Serene.Web/Modules/Workflow/Handlers/StartTaskWorkflowHandler.cs
+++ b/serene/src/Serene.Web/Modules/Workflow/Handlers/StartTaskWorkflowHandler.cs
@@ -14,10 +14,15 @@ public class StartTaskWorkflowHandler(ISqlConnections connections) : IWorkflowAc
         var taskId = Convert.ToInt32(id);
         using var connection = connections.NewByKey("Default");
         var fields = Tasks.TaskItemRow.Fields;
-        new SqlUpdate(fields.TableName)
+        input.TryGetValue("CurrentState", out var cs);
+        var update = new SqlUpdate(fields.TableName)
             .Set(fields.State, "InProgress")
-            .Where(fields.TaskId == taskId)
-            .Execute(connection);
+            .Where(fields.TaskId == taskId);
+        if (cs is string state)
+            update.Where(fields.State == state);
+        var rows = update.Execute(connection, ExpectedRows.ZeroOrOne);
+        if (rows == 0)
+            throw new InvalidOperationException("Concurrent modification detected");
 
         return Task.CompletedTask;
     }

--- a/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
+++ b/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
@@ -75,6 +75,8 @@ namespace Serenity.Workflow
             ArgumentNullException.ThrowIfNull(trigger);
 
             var machine = CreateMachine(workflowKey, currentState);
+            if (input != null)
+                input["CurrentState"] = currentState;
             WorkflowTrigger? action = null;
             definitionProvider.GetDefinition(workflowKey)?.Triggers.TryGetValue(trigger, out action);
 


### PR DESCRIPTION
## Summary
- add storing CurrentState in input before workflow execution
- check current state in workflow handlers to avoid concurrent modification

## Testing
- `pnpm install --frozen-lockfile`
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c42e23b10832eb27773d4ea770a3a