### PR TITLE
Enable async workflow history storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Introduced experimental DateOnlyField type. This required changing target framework of Serenity.Net.Services to net8 (was netstandard2.1).
 - Add Oracle-specific SQL type mappings to SqlTypeToFieldTypeMap (#7363)
 - Add support for partial properties for row fields source generator (requires NET9+)
+- Workflow history store can now record entries asynchronously with optional batching support
 
 ### Bugfixes
 - Also invalidate UserRole / UserPermission cache group when saving user as LinkingSetRelation might be updating roles 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -4,4 +4,6 @@ This repository includes a minimal workflow engine implementation. Workflows are
 
 Services are registered in `Startup.cs` via `AddSerenityWorkflow()` and `AddWorkflowDbProvider()`. The workflow engine no longer falls back to an in-memory history store. Use `AddSerenityWorkflow(o => o.UseInMemoryHistoryStore = true)` to enable the in-memory store or register another `IWorkflowHistoryStore` like the one added by `AddWorkflowDbProvider()`. Generic endpoints are available under `Services/Workflow`.
 
+History store implementations can now record entries asynchronously. `IWorkflowHistoryStore` includes `RecordEntryAsync` and `RecordEntriesAsync` methods which may optionally batch writes when using database-backed stores.
+
 Database tables for the workflow entities are created automatically during application startup as the provider assembly now includes FluentMigrator migrations.

--- a/src/Serenity.Workflow.Abstractions/Engine/IWorkflowHistoryStore.cs
+++ b/src/Serenity.Workflow.Abstractions/Engine/IWorkflowHistoryStore.cs
@@ -1,8 +1,37 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 namespace Serenity.Workflow;
 
 public interface IWorkflowHistoryStore
 {
     void RecordEntry(WorkflowHistoryEntry entry);
     IEnumerable<WorkflowHistoryEntry> GetHistory(string workflowKey, object entityId);
+
+    /// <summary>
+    /// Records the entry asynchronously. Default implementation delegates to
+    /// <see cref="RecordEntry"/>.
+    /// </summary>
+    /// <param name="entry">History entry</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>A task representing the async operation</returns>
+    Task RecordEntryAsync(WorkflowHistoryEntry entry, CancellationToken cancellationToken = default)
+    {
+        RecordEntry(entry);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Records multiple entries asynchronously. Default implementation calls
+    /// <see cref="RecordEntry"/> for each entry.
+    /// </summary>
+    /// <param name="entries">Entries to record</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>A task representing the async operation</returns>
+    Task RecordEntriesAsync(IEnumerable<WorkflowHistoryEntry> entries, CancellationToken cancellationToken = default)
+    {
+        foreach (var entry in entries)
+            RecordEntry(entry);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Serenity.Workflow.Core/Engine/InMemoryWorkflowHistoryStore.cs
+++ b/src/Serenity.Workflow.Core/Engine/InMemoryWorkflowHistoryStore.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Serenity.Workflow;
 
@@ -19,5 +21,21 @@ public class InMemoryWorkflowHistoryStore : IWorkflowHistoryStore
     {
         var list = store.GetOrAdd((entry.WorkflowKey, entry.EntityId), _ => new List<WorkflowHistoryEntry>());
         list.Add(entry);
+    }
+
+    public Task RecordEntriesAsync(IEnumerable<WorkflowHistoryEntry> entries, CancellationToken cancellationToken = default)
+    {
+        if (entries != null)
+        {
+            foreach (var entry in entries)
+                RecordEntry(entry);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task RecordEntryAsync(WorkflowHistoryEntry entry, CancellationToken cancellationToken = default)
+    {
+        RecordEntry(entry);
+        return Task.CompletedTask;
     }
 }

--- a/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
+++ b/src/Serenity.Workflow.Core/Engine/WorkflowEngine.cs
@@ -104,7 +104,7 @@ namespace Serenity.Workflow
                 var userAccessor = services.GetService<IUserAccessor>();
                 var userName = userAccessor?.User?.Identity?.Name;
 
-                historyStore.RecordEntry(new WorkflowHistoryEntry
+                await historyStore.RecordEntryAsync(new WorkflowHistoryEntry
                 {
                     WorkflowKey = workflowKey,
                     EntityId = entityId,

--- a/src/Serenity.Workflow.DbProvider/Store/DBWorkflowHistoryStore.cs
+++ b/src/Serenity.Workflow.DbProvider/Store/DBWorkflowHistoryStore.cs
@@ -1,12 +1,15 @@
 using Serenity.Data;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Serenity.Workflow;
 
-public class DBWorkflowHistoryStore(ISqlConnections connections) : IWorkflowHistoryStore
+public class DBWorkflowHistoryStore(ISqlConnections connections, int batchSize = 1) : IWorkflowHistoryStore
 {
     private readonly ISqlConnections connections = connections ?? throw new ArgumentNullException(nameof(connections));
+    private readonly int batchSize = batchSize <= 0 ? 1 : batchSize;
 
     public IEnumerable<WorkflowHistoryEntry> GetHistory(string workflowKey, object entityId)
     {
@@ -42,5 +45,42 @@ public class DBWorkflowHistoryStore(ISqlConnections connections) : IWorkflowHist
             EventDate = entry.EventDate,
             User = entry.User
         });
+    }
+
+    public async Task RecordEntryAsync(WorkflowHistoryEntry entry, CancellationToken cancellationToken = default)
+    {
+        await RecordEntriesAsync([entry], cancellationToken);
+    }
+
+    public async Task RecordEntriesAsync(IEnumerable<WorkflowHistoryEntry> entries, CancellationToken cancellationToken = default)
+    {
+        if (entries == null)
+            return;
+
+        var list = entries.ToList();
+        if (list.Count == 0)
+            return;
+
+        await Task.Yield();
+
+        using var connection = connections.NewByKey("Default");
+        using var transaction = batchSize > 1 && list.Count > 1 ? connection.BeginTransaction() : null;
+
+        foreach (var entry in list)
+        {
+            connection.Insert(new Entities.WorkflowHistoryRow
+            {
+                WorkflowKey = entry.WorkflowKey,
+                EntityId = entry.EntityId.ToString()!,
+                FromState = entry.FromState,
+                ToState = entry.ToState,
+                Trigger = entry.Trigger,
+                Input = entry.Input == null ? null : JSON.Stringify(entry.Input, writeNulls: true),
+                EventDate = entry.EventDate,
+                User = entry.User
+            });
+        }
+
+        transaction?.Commit();
     }
 }


### PR DESCRIPTION
## Summary
- add asynchronous recording APIs to `IWorkflowHistoryStore`
- implement async and optional batching in DB history store
- support async methods in in-memory store and workflow engine
- document async history recording

## Testing
- `dotnet build -c Release` *(fails: project not found)*
- `dotnet test` *(fails: project not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c43114058832eb9039855802ea044