### PR TITLE
Fix Workflow History date handling

### DIFF
--- a/src/Serenity.Workflow.DbProvider/Store/DBWorkflowHistoryStore.cs
+++ b/src/Serenity.Workflow.DbProvider/Store/DBWorkflowHistoryStore.cs
@@ -1,4 +1,5 @@
 using Serenity.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -26,7 +27,7 @@ public class DBWorkflowHistoryStore(ISqlConnections connections, int batchSize =
             ToState = x.ToState!,
             Trigger = x.Trigger!,
             Input = x.Input == null ? null : JSON.Parse<Dictionary<string, object?>>(x.Input),
-            EventDate = x.EventDate ?? DateTime.UtcNow,
+            EventDate = x.EventDate != null ? DateTime.SpecifyKind(x.EventDate.Value, DateTimeKind.Utc) : DateTime.UtcNow,
             User = x.User
         });
     }


### PR DESCRIPTION
## Summary
- handle UTC dates when returning workflow history

## Testing
- `pnpm -r test` *(fails: Cannot find package 'esbuild')*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f8c5138832e8c0c68b62b0cf594