### PR TITLE
Fix dynamic workflow selection for documents

### DIFF
--- a/serene/src/Serene.Web/Modules/Documents/DocumentDialog.ts
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentDialog.ts
@@ -13,6 +13,13 @@ export class DocumentDialog extends WorkflowEntityDialog<DocumentRow, any> {
 
     protected form = new DocumentForm(this.idPrefix);
 
+    constructor() {
+        super();
+        this.form.DocumentType.changeSelect2(() => {
+            this.reloadWorkflow();
+        });
+    }
+
     //protected getWorkflowKey() { return 'DocumentWorkflow'; }
 
     protected getWorkflowKey() {
@@ -24,6 +31,12 @@ export class DocumentDialog extends WorkflowEntityDialog<DocumentRow, any> {
             default:
                 return 'DocumentWorkflow1';
         }
+    }
+
+
+    protected override afterLoadEntity() {
+        super.afterLoadEntity();
+        this.reloadWorkflow();
     }
 
     protected getStateProperty(): keyof DocumentRow { return 'State'; }

--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.tsx
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.tsx
@@ -8,14 +8,22 @@ export abstract class WorkflowEntityDialog<TItem, TOptions> extends EntityDialog
     protected abstract getWorkflowKey(): string;
     protected abstract getStateProperty(): keyof TItem;
 
-    private workflow?: WorkflowDefinition;
+    protected workflow?: WorkflowDefinition;
     private workflowGroup?: HTMLElement;
 
     protected async ensureDefinition() {
-        if (this.workflow)
+        const key = this.getWorkflowKey();
+        if (this.workflow?.WorkflowKey === key)
             return;
-        const r = await WorkflowService.GetDefinition({ WorkflowKey: this.getWorkflowKey() });
+        const r = await WorkflowService.GetDefinition({ WorkflowKey: key });
         this.workflow = r.Definition!;
+    }
+
+    protected async reloadWorkflow() {
+        this.workflow = undefined;
+        await this.ensureDefinition();
+        this.updateHistoryButton();
+        this.updateTriggers();
     }
 
     protected override getToolbarButtons(): ToolButton[] {


### PR DESCRIPTION
## Summary
- ensure workflow definition refreshes when key changes
- reload workflow in `DocumentDialog` when document type changes or after load

## Testing
- `pnpm -r tsc`
- `pnpm -r build`
- `pnpm -r test` *(fails: `@serenity-is/extensions@ test`)*

------
https://chatgpt.com/codex/tasks/task_e_68510098ecfc832e9ac761b330f60139