### PR TITLE
Fix duplicate history buttons

### DIFF
--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.tsx
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowEntityDialog.tsx
@@ -100,6 +100,8 @@ export abstract class WorkflowEntityDialog<TItem, TOptions> extends EntityDialog
             WorkflowKey: this.getWorkflowKey(),
             EntityId: entity[this.getIdProperty()]
         }).then(r => {
+            // remove any existing history button in case multiple calls overlap
+            this.workflowGroup!.querySelector('.workflow-history-button')?.remove();
             if ((r.History?.length ?? 0) > 0) {
                 this.toolbar!.createButton(this.workflowGroup!, {
                     title: 'History',


### PR DESCRIPTION
## Summary
- remove existing history button before recreating in WorkflowEntityDialog

## Testing
- `pnpm -r test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)*
- `dotnet test` *(fails: Repository URL invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6851078ee9a8832ea9aed6a2dc22a248