### PR TITLE
Fix workflow history grid for multi workflow

### DIFF
--- a/serene/src/Serene.Web/Modules/Documents/DocumentGrid.ts
+++ b/serene/src/Serene.Web/Modules/Documents/DocumentGrid.ts
@@ -1,5 +1,5 @@
 import { EntityGrid, Decorators } from "@serenity-is/corelib";
-import { DocumentRow, DocumentColumns, DocumentService } from "../ServerTypes/Documents";
+import { DocumentRow, DocumentColumns, DocumentService, DocumentType } from "../ServerTypes/Documents";
 import { DocumentDialog } from "./DocumentDialog";
 import { WorkflowHistoryGridMixin } from "../Workflow/Client/WorkflowHistoryGridMixin";
 
@@ -17,7 +17,16 @@ export class DocumentGrid extends EntityGrid<DocumentRow, any> {
     protected override afterInit() {
         super.afterInit();
         this.history = new WorkflowHistoryGridMixin(this, {
-            workflowKey: 'DocumentWorkflow',
+            workflowKey: (item) => {
+                switch (item.DocumentType) {
+                    case DocumentType.Casual:
+                        return 'DocumentWorkflow';
+                    case DocumentType.Annual:
+                        return 'DocumentWorkflow1';
+                    default:
+                        return 'DocumentWorkflow1';
+                }
+            },
             idField: DocumentRow.idProperty as keyof DocumentRow
         });
     }

--- a/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryGridMixin.ts
+++ b/serene/src/Serene.Web/Modules/Workflow/Client/WorkflowHistoryGridMixin.ts
@@ -2,7 +2,7 @@ import { DataGrid, htmlEncode } from "@serenity-is/corelib";
 import { WorkflowService } from "./WorkflowService";
 
 export interface WorkflowHistoryGridMixinOptions<TItem> {
-    workflowKey: string;
+    workflowKey: string | ((item: TItem) => string);
     idField: keyof TItem;
 }
 
@@ -33,6 +33,9 @@ export class WorkflowHistoryGridMixin<TItem> {
         const rowEl = cell.parentElement as HTMLElement;
         const item = this.grid.itemAt(row) as any;
         const id = item[this.options.idField];
+        const workflowKey = typeof this.options.workflowKey === 'function'
+            ? this.options.workflowKey(item)
+            : this.options.workflowKey;
         const detail = document.createElement('div');
         detail.classList.add('workflow-history-detail');
         detail.innerHTML = '<div>Loading...</div>';
@@ -53,7 +56,7 @@ export class WorkflowHistoryGridMixin<TItem> {
         this.detailRow = detail;
         this.rowIndex = row;
         const resp = await WorkflowService.GetHistory({
-            WorkflowKey: this.options.workflowKey,
+            WorkflowKey: workflowKey,
             EntityId: id
         });
         const table = document.createElement('table');


### PR DESCRIPTION
## Summary
- allow `WorkflowHistoryGridMixin` to accept a callback to determine workflow key
- update `DocumentGrid` to supply workflow key based on document type

## Testing
- `dotnet build Serenity.sln -p:RepositoryUrl="https://example.com"`
- `dotnet test Serenity.sln -p:RepositoryUrl="https://example.com"`


------
https://chatgpt.com/codex/tasks/task_e_68510c67bc40832eb2ff8bfd14d79de4