### PR TITLE
Add lazy loading for JSON local texts

### DIFF
--- a/src/Serenity.Net.Core/Localization/JsonLocalTextRegistration.cs
+++ b/src/Serenity.Net.Core/Localization/JsonLocalTextRegistration.cs
@@ -89,10 +89,21 @@ public static class JsonLocalTextRegistration
             if (langID is null)
                 continue;
 
-            var texts = JSON.Parse<Dictionary<string, object>>(
-                fileSystem.ReadAllText(file).TrimToNull() ?? "{}") ?? [];
-
-            AddFromNestedDictionary(texts, "", langID, registry);
+            if (registry is LocalTextRegistry ltr)
+            {
+                var filePath = file;
+                ltr.RegisterJsonLoader(langID, () =>
+                {
+                    var jsonText = fileSystem.ReadAllText(filePath).TrimToNull();
+                    return jsonText is null ? null : JSON.Parse<Dictionary<string, object>>(jsonText);
+                });
+            }
+            else
+            {
+                var texts = JSON.Parse<Dictionary<string, object>>(
+                    fileSystem.ReadAllText(file).TrimToNull() ?? "{}") ?? [];
+                AddFromNestedDictionary(texts, "", langID, registry);
+            }
         }
     }
 

--- a/src/Serenity.Net.Core/Localization/LocalTextRegistry.cs
+++ b/src/Serenity.Net.Core/Localization/LocalTextRegistry.cs
@@ -19,6 +19,8 @@ public class LocalTextRegistry : ILocalTextRegistry, IRemoveAll, IGetAllTexts, I
 
     private readonly ConcurrentDictionary<string, string> languageFallbacks = new(StringComparer.OrdinalIgnoreCase);
 
+    private readonly ConcurrentDictionary<string, List<Func<Dictionary<string, object>?>>> lazyJsonTexts = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>
     /// Adds a local text entry to the registry
     /// </summary>
@@ -62,6 +64,37 @@ public class LocalTextRegistry : ILocalTextRegistry, IRemoveAll, IGetAllTexts, I
         pendingTexts[new LanguageIdKeyPair(languageID, key)] = text;
     }
 
+    private void EnsureJsonTextsLoaded(string languageID)
+    {
+        if (!lazyJsonTexts.TryGetValue(languageID, out var loaders))
+            return;
+
+        lock (loaders)
+        {
+            if (loaders.Count == 0)
+                return;
+
+            foreach (var loader in loaders.ToArray())
+            {
+                var texts = loader();
+                if (texts is not null)
+                    JsonLocalTextRegistration.AddFromNestedDictionary(texts, "", languageID, this);
+            }
+
+            loaders.Clear();
+        }
+    }
+
+    internal void RegisterJsonLoader(string languageID, Func<Dictionary<string, object>?> loader)
+    {
+        ArgumentNullException.ThrowIfNull(languageID);
+        ArgumentNullException.ThrowIfNull(loader);
+
+        var list = lazyJsonTexts.GetOrAdd(languageID, static _ => []);
+        lock (list)
+            list.Add(loader);
+    }
+
     /// <summary>
     /// Converts the local text key to its representation in requested language. Looks up text
     /// in requested language, its Fallbacks and invariant language in order. If not found in any,
@@ -77,7 +110,8 @@ public class LocalTextRegistry : ILocalTextRegistry, IRemoveAll, IGetAllTexts, I
 
         if (textKey == null)
             throw new ArgumentNullException(nameof(textKey));
-        
+        EnsureJsonTextsLoaded(languageID);
+
         var circularCheck = 0;
         LanguageIdKeyPair k;
         do
@@ -96,6 +130,7 @@ public class LocalTextRegistry : ILocalTextRegistry, IRemoveAll, IGetAllTexts, I
                 return null;
 
             languageID = TryGetLanguageFallback(languageID) ?? LocalText.InvariantLanguageID;
+            EnsureJsonTextsLoaded(languageID);
         }
         while (circularCheck++ < 10);
 
@@ -229,5 +264,6 @@ public class LocalTextRegistry : ILocalTextRegistry, IRemoveAll, IGetAllTexts, I
         approvedTexts.Clear();
         pendingTexts.Clear();
         languageFallbacks.Clear();
+        lazyJsonTexts.Clear();
     }
 }

--- a/src/Serenity.Net.Core/Localization/LocalTextRegistry.cs
+++ b/src/Serenity.Net.Core/Localization/LocalTextRegistry.cs
@@ -85,10 +85,18 @@ public class LocalTextRegistry : ILocalTextRegistry, IRemoveAll, IGetAllTexts, I
         }
     }
 
-    internal void RegisterJsonLoader(string languageID, Func<Dictionary<string, object>?> loader)
+    /// <summary>
+    /// Registers a lazy JSON loader for a language.
+    /// </summary>
+    /// <param name="languageID">Language ID to register for.</param>
+    /// <param name="loader">Loader delegate returning the JSON dictionary.</param>
+    public void RegisterJsonLoader(string languageID, Func<Dictionary<string, object>?> loader)
     {
-        ArgumentNullException.ThrowIfNull(languageID);
-        ArgumentNullException.ThrowIfNull(loader);
+        if (languageID == null)
+            throw new ArgumentNullException(nameof(languageID));
+
+        if (loader == null)
+            throw new ArgumentNullException(nameof(loader));
 
         var list = lazyJsonTexts.GetOrAdd(languageID, static _ => []);
         lock (list)

--- a/tests/Serenity.Net.Tests/core/localization/LazyJsonTextsTests.cs
+++ b/tests/Serenity.Net.Tests/core/localization/LazyJsonTextsTests.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using Serenity.Localization;
+using Serenity.TestUtils;
+
+public class LazyJsonTextsTests
+{
+    private class TrackingFileSystem : MockFileSystem
+    {
+        public int ReadCount { get; private set; }
+
+        public new string ReadAllText(string path, Encoding encoding = null)
+        {
+            ReadCount++;
+            return base.ReadAllText(path, encoding);
+        }
+    }
+
+    [Fact]
+    public void JsonTexts_Loads_On_First_Access()
+    {
+        var fs = new TrackingFileSystem();
+        fs.AddFile(@"/My/en.json", "{\"x\":\"1\"}");
+        var registry = new LocalTextRegistry();
+
+        JsonLocalTextRegistration.AddJsonTexts(registry, "/My", fs);
+
+        Assert.Equal(0, fs.ReadCount);
+        Assert.Equal("1", registry.TryGet("en", "x", pending: false));
+        Assert.Equal(1, fs.ReadCount);
+        Assert.Equal("1", registry.TryGet("en", "x", pending: false));
+        Assert.Equal(1, fs.ReadCount);
+    }
+
+    [Fact]
+    public void JsonTexts_Loads_Fallback_On_Demand()
+    {
+        var fs = new TrackingFileSystem();
+        fs.AddFile(@"/My/en.json", "{\"x\":\"1\"}");
+        fs.AddFile(@"/My/en-US.json", "{\"y\":\"2\"}");
+        var registry = new LocalTextRegistry();
+
+        JsonLocalTextRegistration.AddJsonTexts(registry, "/My", fs);
+
+        Assert.Equal("1", registry.TryGet("en-US", "x", pending: false));
+        Assert.Equal(2, fs.ReadCount);
+        Assert.Equal("2", registry.TryGet("en-US", "y", pending: false));
+        Assert.Equal(2, fs.ReadCount);
+    }
+}


### PR DESCRIPTION
## Summary
- register JSON text files lazily in `JsonLocalTextRegistration`
- load JSON files on demand in `LocalTextRegistry`
- support lazy loading in service helper `AddJsonTexts`
- test lazy loading behavior

## Testing
- `dotnet test Serenity.sln` *(fails: Repository Url not valid)*

------
https://chatgpt.com/codex/tasks/task_e_685e4d7acc1c832e8f53933bbb08a803