### PR TITLE
Fix property metadata provider fallback

### DIFF
--- a/src/Serenity.Net.Services.Generators/PropertyMetadataGenerator.cs
+++ b/src/Serenity.Net.Services.Generators/PropertyMetadataGenerator.cs
@@ -50,10 +50,7 @@ public class PropertyMetadataGenerator : ISourceGenerator
             }
         }
 
-        if (propertyData.Count == 0)
-            return;
-
-        var json = JsonSerializer.Serialize(propertyData);
+        var json = propertyData.Count == 0 ? "" : JsonSerializer.Serialize(propertyData);
         var source = $@"namespace Serenity.PropertyMetadata; internal static class GeneratedMetadata {{ public const string Json = @""{json}""; }}";
         context.AddSource("PropertyMetadata.g.cs", SourceText.From(source, Encoding.UTF8));
     }

--- a/src/Serenity.Net.Services/Entity/PropertyGrid/DefaultPropertyItemProvider.Generated.cs
+++ b/src/Serenity.Net.Services/Entity/PropertyGrid/DefaultPropertyItemProvider.Generated.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Serenity.Net.Services.Generators;
+using System.Reflection;
 
 namespace Serenity.PropertyGrid;
 
@@ -7,12 +7,14 @@ public partial class DefaultPropertyItemProvider
 {
     partial void LoadGeneratedMetadata(Type type, List<PropertyItem> list)
     {
-        if (string.IsNullOrEmpty(GeneratedMetadata.Json))
+        var metadataType = Type.GetType("Serenity.PropertyMetadata.GeneratedMetadata");
+        if (metadataType?.GetField("Json", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) is not string json ||
+            string.IsNullOrEmpty(json))
             return;
 
         try
         {
-            var all = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(GeneratedMetadata.Json);
+            var all = JsonSerializer.Deserialize<List<Dictionary<string, string>>>(json);
             if (all == null)
                 return;
 


### PR DESCRIPTION
## Summary
- use reflection to load GeneratedMetadata so build passes without analyzers
- generate empty metadata class even when no properties are found

## Testing
- `dotnet build src/Serenity.Net.Services/Serenity.Net.Services.csproj -c Release -p:RepositoryUrl=https://example.com -p:RunAnalyzers=false`
- `dotnet test Serenity.sln -c Release -p:RepositoryUrl=https://example.com -p:RunAnalyzers=false` *(fails: missing references in test projects)*

------
https://chatgpt.com/codex/tasks/task_e_685eb52a88cc832eb5468d496040b75a