### PR TITLE
Replace reserved keyword sets with arrays

### DIFF
--- a/src/Serenity.Net.Services/Data/Dialects/FirebirdDialect.cs
+++ b/src/Serenity.Net.Services/Data/Dialects/FirebirdDialect.cs
@@ -11,8 +11,13 @@ public class FirebirdDialect : ISqlDialect
     /// </summary>
     public static readonly FirebirdDialect Instance = new();
 
-    private static readonly HashSet<string> keywords = new(StringComparer.OrdinalIgnoreCase)
+    static FirebirdDialect()
     {
+        Array.Sort(keywords, StringComparer.OrdinalIgnoreCase);
+        Array.Sort(ReservedKeywords, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static readonly string[] keywords = [
         "!<", "^<", "^=", "^>", ",", ":=", "!=", "!>", "(", ")", "<", "<=", "<>", "=", ">", ">=", "||", "~<", "~=", "~>",
         "ABS", "ACCENT", "ACOS", "ACTION", "ACTIVE", "ADD", "ADMIN", "AFTER", "ALL", "ALTER", "ALWAYS", "AND", "ANY",
         "AS", "ASC", "ASCENDING", "ASCII_CHAR", "ASCII_VAL", "ASIN", "AT", "ATAN", "ATAN2", "AUTO", "AUTONOMOUS", "AVG",
@@ -43,7 +48,7 @@ public class FirebirdDialect : ISqlDialect
         "TRUNC", "TWO_PHASE", "TYPE", "UNCOMMITTED", "UNDO", "UNION", "UNIQUE", "UPDATE", "UPDATING", "UPPER", "USER", "USING", "UUID_TO_CHAR",
         "VALUE", "VALUES", "VARCHAR", "VARIABLE", "VARYING", "VIEW", "WAIT", "WEEK", "WEEKDAY", "WHEN", "WHERE", "WHILE", "WITH", "WORK",
         "WRITE", "YEAR", "YEARDAY"
-    };
+    ];
 
     /// <inheritdoc/>
     public virtual bool CanUseConcat => false;
@@ -189,7 +194,7 @@ public class FirebirdDialect : ISqlDialect
         if (s.StartsWith("\"") && s.EndsWith("\""))
             return s;
 
-        if (keywords.Contains(s) || s.IndexOf(' ') >= 0 || s.StartsWith("_"))
+        if (SqlKeywordLookup.IsReserved(keywords, s) || s.IndexOf(' ') >= 0 || s.StartsWith("_"))
             return '"' + s + '"';
 
         return s;
@@ -326,10 +331,10 @@ public class FirebirdDialect : ISqlDialect
     /// <inheritdoc />
     public virtual bool IsReservedKeyword(string s)
     {
-        return ReservedKeywords.Contains(s);
+        return SqlKeywordLookup.IsReserved(ReservedKeywords, s);
     }
 
-    internal static readonly HashSet<string> ReservedKeywords = new([
+    internal static readonly string[] ReservedKeywords = [
         "ADD",
         "ADMIN",
         "ALL",
@@ -527,5 +532,5 @@ public class FirebirdDialect : ISqlDialect
         "WHILE",
         "WITH",
         "YEAR",
-    ], StringComparer.OrdinalIgnoreCase);
+    ];
 }

--- a/src/Serenity.Net.Services/Data/Dialects/MySqlDialect.cs
+++ b/src/Serenity.Net.Services/Data/Dialects/MySqlDialect.cs
@@ -11,6 +11,11 @@ public class MySqlDialect : ISqlDialect
     /// </summary>
     public static readonly ISqlDialect Instance = new MySqlDialect();
 
+    static MySqlDialect()
+    {
+        Array.Sort(ReservedKeywords, StringComparer.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// Gets a value indicating whether the server supports OFFSET FETCH.
     /// </summary>
@@ -285,10 +290,10 @@ public class MySqlDialect : ISqlDialect
     /// <inheritdoc />
     public virtual bool IsReservedKeyword(string s)
     {
-        return ReservedKeywords.Contains(s);
+        return SqlKeywordLookup.IsReserved(ReservedKeywords, s);
     }
 
-    internal static readonly HashSet<string> ReservedKeywords = new([
+    internal static readonly string[] ReservedKeywords = [
         "ACCESSIBLE",
         "ADD",
         "ALL",
@@ -559,5 +564,5 @@ public class MySqlDialect : ISqlDialect
         "XOR",
         "YEAR_MONTH",
         "ZEROFILL",
-    ], StringComparer.OrdinalIgnoreCase);
+    ];
 }

--- a/src/Serenity.Net.Services/Data/Dialects/OracleDialect.cs
+++ b/src/Serenity.Net.Services/Data/Dialects/OracleDialect.cs
@@ -6,7 +6,7 @@ namespace Serenity.Data;
 /// <seealso cref="ISqlDialect" />
 public class OracleDialect : ISqlDialect
 {
-    private static readonly HashSet<string> keywords = new([
+    private static readonly string[] keywords = [
         "ACCESS", "ACCOUNT", "ACTIVATE", "ADD", "ADMIN", "ADVISE", "AFTER", "ALL", "ALL_ROWS", "ALLOCATE", "ALTER", "ANALYZE", "AND", "ANY", "ARCHIVE", "ARCHIVELOG", "ARRAY", "AS", "ASC", "AT", "AUDIT", "AUTHENTICATED", "AUTHORIZATION", "AUTOEXTEND", "AUTOMATIC",
         "BACKUP", "BECOME", "BEFORE", "BEGIN", "BETWEEN", "BFILE", "BITMAP", "BLOB", "BLOCK", "BODY", "BY",
         "CACHE", "CACHE_INSTANCES", "CANCEL", "CASCADE", "CAST", "CFILE", "CHAINED", "CHANGE", "CHAR", "CHAR_CS", "CHARACTER", "CHECK", "CHECKPOINT", "CHOOSE", "CHUNK", "CLEAR", "CLOB", "CLONE", "CLOSE", "CLOSE_CACHED_OPEN_CURSORS", "CLUSTER", "COALESCE", "COLUMN", "COLUMNS", "COMMENT", "COMMIT", "COMMITTED", "COMPATIBILITY", "COMPILE", "COMPLETE", "COMPOSITE_LIMIT", "COMPRESS",
@@ -22,12 +22,18 @@ public class OracleDialect : ISqlDialect
         "RESTRICTED", "RETURN", "RETURNING", "REUSE", "REVERSE", "REVOKE", "ROLE", "ROLES", "ROLLBACK", "ROW", "ROWID", "ROWNUM", "ROWS", "RULE", "SAMPLE", "SAVEPOINT", "SB4", "SCAN_INSTANCES", "SCHEMA", "SCN", "SCOPE", "SD_ALL", "SD_INHIBIT", "SD_SHOW", "SEGMENT", "SEG_BLOCK", "SEG_FILE", "SELECT", "SEQUENCE", "SERIALIZABLE", "SESSION", "SESSION_CACHED_CURSORS", "SESSIONS_PER_USER", "SET", "SHARE", "SHARED", "SHARED_POOL", "SHRINK", "SIZE", "SKIP",
         "SKIP_UNUSABLE_INDEXES", "SMALLINT", "SNAPSHOT", "SOME", "SORT", "SPECIFICATION", "SPLIT", "SQL_TRACE", "STANDBY", "START", "STATEMENT_ID", "STATISTICS", "STOP", "STORAGE", "STORE", "STRUCTURE", "SUCCESSFUL", "SWITCH", "SYS_OP_ENFORCE_NOT_NULL$", "SYS_OP_NTCIMG$", "SYNONYM", "SYSDATE", "SYSDBA", "SYSOPER", "SYSTEM", "TABLE", "TABLES", "TABLESPACE", "TABLESPACE_NO", "TABNO", "TEMPORARY", "THAN", "THE", "THEN", "THREAD", "TIMESTAMP", "TIME", "TO", "TOPLEVEL",
         "TRACE", "TRACING", "TRANSACTION", "TRANSITIONAL", "TRIGGER", "TRIGGERS", "TRUE", "TRUNCATE", "TX", "TYPE", "UB2", "UBA", "UID", "UNARCHIVED", "UNDO", "UNION", "UNIQUE", "UNLIMITED", "UNLOCK", "UNRECOVERABLE", "UNTIL", "UNUSABLE", "UNUSED", "UPDATABLE", "UPDATE", "USAGE", "USE", "USER", "USING", "VALIDATE", "VALIDATION", "VALUE", "VALUES", "VARCHAR", "VARCHAR2", "VARYING", "VIEW", "WHEN", "WHENEVER", "WHERE", "WITH", "WITHOUT", "WORK", "WRITE", "WRITEDOWN", "WRITEUP", "XID", "YEAR", "ZONE"
-    ], StringComparer.OrdinalIgnoreCase);
+    ];
 
     /// <summary>
     /// The shared instance of OracleDialect.
     /// </summary>
     public static readonly ISqlDialect Instance = new OracleDialect();
+
+    static OracleDialect()
+    {
+        Array.Sort(keywords, StringComparer.OrdinalIgnoreCase);
+        Array.Sort(ReservedKeywords, StringComparer.OrdinalIgnoreCase);
+    }
 
     /// <summary>
     /// Gets a value indicating whether the server supports OFFSET FETCH.
@@ -176,7 +182,7 @@ public class OracleDialect : ISqlDialect
         if (s.StartsWith("\"") && s.EndsWith("\""))
             return s;
 
-        if (keywords.Contains(s) || s.IndexOf(' ') >= 0)
+        if (SqlKeywordLookup.IsReserved(keywords, s) || s.IndexOf(' ') >= 0)
             return '"' + s.ToUpperInvariant() + '"';
 
         return s;
@@ -316,10 +322,10 @@ public class OracleDialect : ISqlDialect
     /// <inheritdoc />
     public virtual bool IsReservedKeyword(string s)
     {
-        return ReservedKeywords.Contains(s);
+        return SqlKeywordLookup.IsReserved(ReservedKeywords, s);
     }
 
-    internal static readonly HashSet<string> ReservedKeywords = new([
+    internal static readonly string[] ReservedKeywords = [
         "ACCESS",
         "ADD",
         "ALL",
@@ -448,5 +454,5 @@ public class OracleDialect : ISqlDialect
         "WHENEVER",
         "WHERE",
         "WITH",
-    ], StringComparer.OrdinalIgnoreCase);
+    ];
 }

--- a/src/Serenity.Net.Services/Data/Dialects/PostgresDialect.cs
+++ b/src/Serenity.Net.Services/Data/Dialects/PostgresDialect.cs
@@ -11,6 +11,11 @@ public class PostgresDialect : ISqlDialect
     /// </summary>
     public static readonly ISqlDialect Instance = new PostgresDialect();
 
+    static PostgresDialect()
+    {
+        Array.Sort(ReservedKeywords, StringComparer.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// Gets a value indicating whether the server supports OFFSET FETCH.
     /// </summary>
@@ -289,10 +294,10 @@ public class PostgresDialect : ISqlDialect
     /// <inheritdoc />
     public virtual bool IsReservedKeyword(string s)
     {
-        return ReservedKeywords.Contains(s);
+        return SqlKeywordLookup.IsReserved(ReservedKeywords, s);
     }
 
-    internal static readonly HashSet<string> ReservedKeywords = new([
+    internal static readonly string[] ReservedKeywords = [
         "ABS",
         "ABSOLUTE",
         "ACCESS",
@@ -813,5 +818,5 @@ public class PostgresDialect : ISqlDialect
         "XMIN",
         "YEAR",
         "ZONE",
-    ], StringComparer.OrdinalIgnoreCase);
+    ];
 }

--- a/src/Serenity.Net.Services/Data/Dialects/SqlServer2000Dialect.cs
+++ b/src/Serenity.Net.Services/Data/Dialects/SqlServer2000Dialect.cs
@@ -11,6 +11,11 @@ public class SqlServer2000Dialect : ISqlDialect
     /// </summary>
     public static readonly ISqlDialect Instance = new SqlServer2000Dialect();
 
+    static SqlServer2000Dialect()
+    {
+        Array.Sort(ReservedKeywords, StringComparer.OrdinalIgnoreCase);
+    }
+
     /// <inheritdoc/>
     public virtual bool CanUseConcat => false;
 
@@ -296,7 +301,7 @@ public class SqlServer2000Dialect : ISqlDialect
     /// </value>
     public virtual char ParameterPrefix => '@';
 
-    internal static readonly HashSet<string> ReservedKeywords = new([
+    internal static readonly string[] ReservedKeywords = [
         "ADD",
         "ALL",
         "ALTER",
@@ -482,11 +487,11 @@ public class SqlServer2000Dialect : ISqlDialect
         "WITH",
         "WITHIN GROUP",
         "WRITETEXT"
-    ], StringComparer.OrdinalIgnoreCase);
+    ];
 
     /// <inheritdoc />
     public bool IsReservedKeyword(string keyword)
     {
-        return ReservedKeywords.Contains(keyword);
+        return SqlKeywordLookup.IsReserved(ReservedKeywords, keyword);
     }
 }

--- a/src/Serenity.Net.Services/Data/Dialects/SqliteDialect.cs
+++ b/src/Serenity.Net.Services/Data/Dialects/SqliteDialect.cs
@@ -11,6 +11,11 @@ public class SqliteDialect : ISqlDialect
     /// </summary>
     public static ISqlDialect Instance = new SqliteDialect();
 
+    static SqliteDialect()
+    {
+        Array.Sort(ReservedKeywords, StringComparer.OrdinalIgnoreCase);
+    }
+
     /// <inheritdoc/>
     public virtual bool CanUseConcat => false;
 
@@ -289,10 +294,10 @@ public class SqliteDialect : ISqlDialect
     /// <inheritdoc />
     public virtual bool IsReservedKeyword(string s)
     {
-        return ReservedKeywords.Contains(s);
+        return SqlKeywordLookup.IsReserved(ReservedKeywords, s);
     }
 
-    internal static readonly HashSet<string> ReservedKeywords = new([
+    internal static readonly string[] ReservedKeywords = [
         "ABORT",
         "ACTION",
         "ADD",
@@ -440,5 +445,5 @@ public class SqliteDialect : ISqlDialect
         "WINDOW",
         "WITH",
         "WITHOUT",
-    ], StringComparer.OrdinalIgnoreCase);
+    ];
 }

--- a/src/Serenity.Net.Services/Data/SqlHelpers/SqlKeywordLookup.cs
+++ b/src/Serenity.Net.Services/Data/SqlHelpers/SqlKeywordLookup.cs
@@ -1,0 +1,32 @@
+namespace Serenity.Data;
+
+public static class SqlKeywordLookup
+{
+    public static bool IsReserved(string[] keywords, string value)
+    {
+        if (string.IsNullOrEmpty(value) || keywords.Length == 0)
+            return false;
+        return IsReserved((ReadOnlySpan<string>)keywords, value);
+    }
+
+    public static bool IsReserved(ReadOnlySpan<string> keywords, string value)
+    {
+        if (string.IsNullOrEmpty(value) || keywords.Length == 0)
+            return false;
+
+        int left = 0;
+        int right = keywords.Length - 1;
+        while (left <= right)
+        {
+            int mid = (left + right) >> 1;
+            int cmp = string.Compare(keywords[mid], value, StringComparison.OrdinalIgnoreCase);
+            if (cmp == 0)
+                return true;
+            if (cmp < 0)
+                left = mid + 1;
+            else
+                right = mid - 1;
+        }
+        return false;
+    }
+}

--- a/src/Serenity.Net.Services/Data/SqlHelpers/SqlSyntax.cs
+++ b/src/Serenity.Net.Services/Data/SqlHelpers/SqlSyntax.cs
@@ -74,15 +74,19 @@ public static class SqlSyntax
             return "T" + joinIndex.ToString(_invariant) + ".";
     }
 
-    private static readonly HashSet<string> ReservedKeywordForAny =
-        new([
-            ..FirebirdDialect.ReservedKeywords,
-            ..MySqlDialect.ReservedKeywords,
-            ..OracleDialect.ReservedKeywords,
-            ..PostgresDialect.ReservedKeywords,
-            ..SqliteDialect.ReservedKeywords,
-            ..SqlServer2000Dialect.ReservedKeywords
-        ], StringComparer.OrdinalIgnoreCase);
+    private static readonly string[] ReservedKeywordForAny;
+
+    static SqlSyntax()
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        set.UnionWith(FirebirdDialect.ReservedKeywords);
+        set.UnionWith(MySqlDialect.ReservedKeywords);
+        set.UnionWith(OracleDialect.ReservedKeywords);
+        set.UnionWith(PostgresDialect.ReservedKeywords);
+        set.UnionWith(SqliteDialect.ReservedKeywords);
+        set.UnionWith(SqlServer2000Dialect.ReservedKeywords);
+        ReservedKeywordForAny = set.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray();
+    }
 
     /// <summary>
     /// Returns true if the specified identifier is a SQL keyword in any of the
@@ -94,7 +98,7 @@ public static class SqlSyntax
         if (string.IsNullOrEmpty(identifier))
             return false;
 
-        return ReservedKeywordForAny.Contains(identifier);
+        return SqlKeywordLookup.IsReserved(ReservedKeywordForAny, identifier);
     }
 
     /// <summary>

--- a/tests/Serenity.Net.Tests/data/dialects/ReservedKeywordTests.cs
+++ b/tests/Serenity.Net.Tests/data/dialects/ReservedKeywordTests.cs
@@ -1,0 +1,31 @@
+namespace Serenity.Data;
+
+public class ReservedKeywordTests
+{
+    [Fact]
+    public void SqlSyntax_Recognizes_Reserved_Keyword()
+    {
+        Assert.True(SqlSyntax.IsReservedKeywordForAny("SELECT"));
+        Assert.False(SqlSyntax.IsReservedKeywordForAny("NOTAKEYWORD"));
+    }
+
+    [Fact]
+    public void Dialects_Recognize_Reserved_Words()
+    {
+        var dialects = new ISqlDialect[]
+        {
+            FirebirdDialect.Instance,
+            MySqlDialect.Instance,
+            OracleDialect.Instance,
+            PostgresDialect.Instance,
+            SqliteDialect.Instance,
+            SqlServer2000Dialect.Instance
+        };
+
+        foreach (var d in dialects)
+        {
+            Assert.True(d.IsReservedKeyword("SELECT"));
+            Assert.False(d.IsReservedKeyword("NOTAKEYWORD"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- convert dialect keyword lists from `HashSet<string>` to sorted arrays
- add `SqlKeywordLookup` helper using binary search
- build `ReservedKeywordForAny` array in `SqlSyntax`
- update dialects to use keyword lookup
- test reserved keyword handling

## Testing
- `dotnet test tests/Serenity.Net.Tests/Serenity.Net.Tests.csproj -p:EnableSourceLink=false --no-build --verbosity minimal` *(fails: LazyJsonTextsTests, WorkflowEngineTests)*

------
https://chatgpt.com/codex/tasks/task_e_685ebc601ac4832eb9b6533ccbd73d29