### PR TITLE
Refactor ScriptBundleManager to load bundles lazily

### DIFF
--- a/tests/Serenity.Net.Tests/web/ScriptBundleWatchTests.cs
+++ b/tests/Serenity.Net.Tests/web/ScriptBundleWatchTests.cs
@@ -24,14 +24,42 @@ public class ScriptBundleWatchTests
         var services = container.BuildServiceProvider();
         services.UseScriptWatching(env.Path.GetDirectoryName(testFile));
         var scriptManager = services.GetRequiredService<IDynamicScriptManager>();
+        var bundleManager = services.GetRequiredService<IScriptBundleManager>();
 
+        Assert.False(scriptManager.IsRegistered("Bundle.Test"));
+        bundleManager.GetScriptBundle("~/" + env.Path.GetFileName(testFile));
         var before = scriptManager.GetScriptText("Bundle.Test");
         Assert.Equal("before", before?.Replace(";", "").Trim());
 
         env.File.WriteAllText(testFile, "after");
         fileWatcherFactory.Watchers.Single().RaiseChanged("test.js");
 
+        bundleManager.GetScriptBundle("~/" + env.Path.GetFileName(testFile));
         var after = scriptManager.GetScriptText("Bundle.Test");
         Assert.Equal("after", after?.Replace(";", "").Trim());
+    }
+
+    [Fact]
+    public void Bundle_Is_Registered_Lazily_On_Demand()
+    {
+        var env = new MockHostEnvironment();
+        var testFile = env.Path.Combine(env.WebRootPath, "test2.js");
+        env.AddWebFile(testFile, "lazy");
+        var container = new ServiceCollection();
+        container.AddSingleton<IWebHostEnvironment>(env);
+        container.AddSingleton<IPermissionService, MockPermissions>();
+        container.AddScriptBundling(options =>
+        {
+            options.Enabled = true;
+            options.Bundles["Lazy"] = [ "~/" + env.Path.GetFileName(testFile) ];
+        });
+        var services = container.BuildServiceProvider();
+        var scriptManager = services.GetRequiredService<IDynamicScriptManager>();
+        var bundleManager = services.GetRequiredService<IScriptBundleManager>();
+
+        Assert.False(scriptManager.IsRegistered("Bundle.Lazy"));
+        var url = bundleManager.GetScriptBundle("~/" + env.Path.GetFileName(testFile));
+        Assert.True(scriptManager.IsRegistered("Bundle.Lazy"));
+        Assert.Contains("Bundle.Lazy.js?v=", url);
     }
 }


### PR DESCRIPTION
## Summary
- simplify `ScriptBundleManager.Reset` so it only captures bundle definitions
- create pool-backed helpers for temporary lists and hashsets
- register script bundles lazily when requested
- rebuild bundles when scripts change
- adjust script bundle watch tests and add a new lazy-registration test

## Testing
- `SergenTransform=none dotnet build --no-restore --property:RepositoryUrl=https://example.com`
- `SergenTransform=none dotnet test --property:RepositoryUrl=https://example.com --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685ebc5b93a8832e94ea18b5e95ff0de